### PR TITLE
Handling atypical integrity levels

### DIFF
--- a/ProcessHacker/ProcessHacker.def
+++ b/ProcessHacker/ProcessHacker.def
@@ -278,6 +278,7 @@ EXPORTS
 	PhGetProcessWorkingSetInformation
 	PhGetProcessWsCounters
 	PhGetTokenGroups
+	PhGetTokenIntegrityLevelRID
 	PhGetTokenIntegrityLevel
 	PhGetTokenOwner
 	PhGetTokenPrimaryGroup

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -922,20 +922,20 @@ INT_PTR CALLBACK PhpTokenPageProc(
                     RECT rect;
                     PPH_EMENU menu;
                     HANDLE tokenHandle;
-                    MANDATORY_LEVEL integrityLevel;
+                    MANDATORY_LEVEL_RID integrityLevelRID;
                     PPH_EMENU_ITEM selectedItem;
 
                     GetWindowRect(GetDlgItem(hwndDlg, IDC_INTEGRITY), &rect);
 
                     menu = PhCreateEMenu();
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelSecureProcess, L"Protected", NULL, NULL), -1);
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelSystem, L"System", NULL, NULL), -1);
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelHigh, L"High", NULL, NULL), -1);
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelMedium, L"Medium", NULL, NULL), -1);
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelLow, L"Low", NULL, NULL), -1);
-                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLevelUntrusted, L"Untrusted", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatorySecureProcessRID, L"Protected", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatorySystemRID, L"System", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryHighRID, L"High", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryMediumRID, L"Medium", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryLowRID, L"Low", NULL, NULL), -1);
+                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, MandatoryUntrustedRID, L"Untrusted", NULL, NULL), -1);
 
-                    integrityLevel = -1;
+                    integrityLevelRID = -1;
 
                     // Put a radio check on the menu item that corresponds with the current integrity level.
                     // Also disable menu items which correspond to higher integrity levels since
@@ -946,24 +946,37 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         tokenPageContext->Context
                         )))
                     {
-                        if (NT_SUCCESS(status = PhGetTokenIntegrityLevel(
+                        if (NT_SUCCESS(status = PhGetTokenIntegrityLevelRID(
                             tokenHandle,
-                            &integrityLevel,
+                            &integrityLevelRID,
                             NULL
                             )))
                         {
+                            ULONG customLevelPosition = 0; // Processing atypical integrity levels
+
                             for (ULONG i = 0; i < menu->Items->Count; i++)
                             {
                                 PPH_EMENU_ITEM menuItem = menu->Items->Items[i];
 
-                                if (menuItem->Id == (ULONG)integrityLevel)
+                                if (menuItem->Id == (ULONG)integrityLevelRID)
                                 {
                                     menuItem->Flags |= PH_EMENU_CHECKED | PH_EMENU_RADIOCHECK;
+                                    customLevelPosition = 0; // The integrity level is a well-known one. No need to add a new menu item.
                                 }
-                                else if (menuItem->Id > (ULONG)integrityLevel)
+                                else if (menuItem->Id > (ULONG)integrityLevelRID)
                                 {
                                     menuItem->Flags |= PH_EMENU_DISABLED;
+                                    customLevelPosition = i + 1;
                                 }
+                            }
+
+                            if (customLevelPosition)
+                            {
+                                PPH_EMENU_ITEM unknownIntegrityItem;
+                                
+                                unknownIntegrityItem = PhCreateEMenuItem(0, (ULONG)integrityLevelRID, L"Custom level", NULL, NULL);
+                                unknownIntegrityItem->Flags |= PH_EMENU_CHECKED | PH_EMENU_RADIOCHECK;
+                                PhInsertEMenuItem(menu, unknownIntegrityItem, customLevelPosition);
                             }
                         }
 
@@ -988,7 +1001,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         rect.bottom
                         );
 
-                    if (selectedItem && selectedItem->Id != integrityLevel)
+                    if (selectedItem && selectedItem->Id != integrityLevelRID)
                     {
                         if (PhShowConfirmMessage(
                             hwndDlg,
@@ -1012,7 +1025,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
 
                                 newSid = (PSID)newSidBuffer;
                                 RtlInitializeSid(newSid, &mandatoryLabelAuthority, 1);
-                                *RtlSubAuthoritySid(newSid, 0) = MANDATORY_LEVEL_TO_MANDATORY_RID(selectedItem->Id);
+                                *RtlSubAuthoritySid(newSid, 0) = selectedItem->Id;
                                 mandatoryLabel.Label.Sid = newSid;
                                 mandatoryLabel.Label.Attributes = SE_GROUP_INTEGRITY;
 

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -974,7 +974,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                             {
                                 PPH_EMENU_ITEM unknownIntegrityItem;
                                 
-                                unknownIntegrityItem = PhCreateEMenuItem(0, (ULONG)integrityLevelRID, L"Custom level", NULL, NULL);
+                                unknownIntegrityItem = PhCreateEMenuItem(0, (ULONG)integrityLevelRID, L"Intermediate level", NULL, NULL);
                                 unknownIntegrityItem->Flags |= PH_EMENU_CHECKED | PH_EMENU_RADIOCHECK;
                                 PhInsertEMenuItem(menu, unknownIntegrityItem, customLevelPosition);
                             }

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -44,6 +44,15 @@ typedef struct _PH_TOKEN_ATTRIBUTES
     ULONG Reserved;
 } PH_TOKEN_ATTRIBUTES, *PPH_TOKEN_ATTRIBUTES;
 
+typedef enum _MANDATORY_LEVEL_RID {
+    MandatoryUntrustedRID = SECURITY_MANDATORY_UNTRUSTED_RID,
+    MandatoryLowRID = SECURITY_MANDATORY_LOW_RID,
+    MandatoryMediumRID = SECURITY_MANDATORY_MEDIUM_RID,
+    MandatoryHighRID = SECURITY_MANDATORY_HIGH_RID,
+    MandatorySystemRID = SECURITY_MANDATORY_SYSTEM_RID,
+    MandatorySecureProcessRID = SECURITY_MANDATORY_PROTECTED_PROCESS_RID
+} MANDATORY_LEVEL_RID, *PMANDATORY_LEVEL_RID;
+
 PHLIBAPI
 PH_TOKEN_ATTRIBUTES
 NTAPI
@@ -397,6 +406,15 @@ NTAPI
 PhSetTokenIsVirtualizationEnabled(
     _In_ HANDLE TokenHandle,
     _In_ BOOLEAN IsVirtualizationEnabled
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
+PhGetTokenIntegrityLevelRID(
+    _In_ HANDLE TokenHandle,
+    _Out_opt_ PMANDATORY_LEVEL_RID IntegrityLevelRID,
+    _Out_opt_ PWSTR *IntegrityString
     );
 
 PHLIBAPI


### PR DESCRIPTION
In addition to well-known integrity levels (like High, Medium, and so on) tokens can have intermediate values of mandatory RIDs. For example, Microsoft's `osk.exe` and `Magnify.exe` while running under a limited user (without admin approval mode) like Guest, have integrity levels that are slightly higher than medium. At the moment Process Hacker can't handle such tokens absolutely correctly. For example, you can't change the integrity level of such a process (all menu items are disabled). The idea is to add a new menu item that represents that custom integrity level for such tokens and make other items work correctly.

![custom-integrity-level](https://user-images.githubusercontent.com/30962924/37731932-98b75008-2d54-11e8-8262-317b46c80b05.png)

The reason for the problem with such tokens is that `PhGetTokenIntegrityLevel` can't work with atypical integrity levels (it fails on such tokens) since it simplifies them up to `MANDATORY_LEVEL`. So, I've added a new function `PhGetTokenIntegrityLevelRID` and used it for Integrity menu on the Token tab. In fact, I am not sure if `PhGetTokenIntegrityLevel` is still necessary since `PhGetTokenIntegrityLevelRID` can provide the same information and also can handle the situation described above. Maybe I should've just replaced one function with another.