### PR TITLE
Fix bringing to front minimized window

### DIFF
--- a/plugins/WindowExplorer/wnddlg.c
+++ b/plugins/WindowExplorer/wnddlg.c
@@ -558,10 +558,12 @@ INT_PTR CALLBACK WepWindowsDlgProc(
 
                         GetWindowPlacement(selectedNode->WindowHandle, &placement);
 
-                        if (placement.showCmd == SW_MINIMIZE)
+                        if (placement.showCmd == SW_SHOWMINIMIZED)
+                        {
                             ShowWindowAsync(selectedNode->WindowHandle, SW_RESTORE);
-                        else
-                            SetForegroundWindow(selectedNode->WindowHandle);
+                        }
+
+                        SetForegroundWindow(selectedNode->WindowHandle);
                     }
                 }
                 break;


### PR DESCRIPTION
Fix make behavior of bring-to-front action same as in ProcessExplorer. Now it just set minimized window active, but don't bring it to front.