### PR TITLE
The thing about PhCreateProcessIgnoreIfeoDebugger 

### DIFF
--- a/ProcessHacker/appsup.c
+++ b/ProcessHacker/appsup.c
@@ -1364,10 +1364,13 @@ BOOLEAN PhCreateProcessIgnoreIfeoDebugger(
         NtClose(processInfo.hProcess);
     if (processInfo.hThread)
         NtClose(processInfo.hThread);
-
-    RtlEnterCriticalSection(NtCurrentPeb()->FastPebLock);
-    NtCurrentPeb()->ReadImageFileExecOptions = originalValue;
-    RtlLeaveCriticalSection(NtCurrentPeb()->FastPebLock);
+    
+    if (originalValue)
+    {
+        RtlEnterCriticalSection(NtCurrentPeb()->FastPebLock);
+        NtCurrentPeb()->ReadImageFileExecOptions = originalValue;
+        RtlLeaveCriticalSection(NtCurrentPeb()->FastPebLock);
+    }    
 
     return result;
 }


### PR DESCRIPTION
One of the last commits a57c091e8268aaee1ba666bf481026e00683fdce pretends to fix thread safety issue for `PhCreateProcessIgnoreIfeoDebugger`, but that's actually not enough. Let's assume that the initial value of `ReadImageFileExecOptions` is True:
1) Thread A enters the first critical section, saves True to `originalValue` and writes False to Peb.
2) Thread B enters the first critical section, saves False to `originalValue` and writes False to Peb.
3) Thread A enters the second critical section and restores True.
4) Thread B enters the second critical section and restores False.

So, the value has changed. The way to fix it is not to restore it forcibly when the `originalValue` is already False.

But before merging this PR... I have a question. What is the point to change the value of `ReadImageFileExecOptions` in Peb? As a matter of fact:

 - ~`DEBUG_PROCESS` is already enough to bypass IFEO Debugger~
 - ~`ReadImageFileExecOptions` without `DEBUG_PROCESS` doesn't work.~

~Maybe this Peb-related code is redundant?~

**UPD:**
Nope, sorry, I was wrong: False value of `ReadImageFileExecOptions` is necessary to bypass it. The question is resolved.