### PR TITLE
Type comparison fix for handle search

### DIFF
--- a/ProcessHacker/findobj.c
+++ b/ProcessHacker/findobj.c
@@ -800,7 +800,7 @@ static BOOLEAN MatchTypeString(
     if (PhEqualString2(Context->SearchTypeString, L"Everything", FALSE))
         return TRUE;
 
-    return PhFindStringInStringRef(Input, &Context->SearchTypeString->sr, TRUE) != -1;
+    return PhEqualStringRef(Input, &Context->SearchTypeString->sr, TRUE);
 }
 
 typedef struct _SEARCH_HANDLE_CONTEXT


### PR DESCRIPTION
The filtration by type (in the handle search dialog) has an issue: it can include the wrong types of handles.
 - "KeyedEvent" handles are also included for "Key"
 - "IoCompletionReserve" for "IoCompletion", and so on.