### PR TITLE
Fix potentially uninitialized access.

### DIFF
--- a/KProcessHacker/object.c
+++ b/KProcessHacker/object.c
@@ -581,7 +581,7 @@ NTSTATUS KpiQueryInformationObject(
     PEPROCESS process;
     KPROCESSOR_MODE referenceMode;
     KAPC_STATE apcState;
-    ULONG returnLength;
+    ULONG returnLength = 0UL;
 
     PAGED_CODE();
 


### PR DESCRIPTION
Using clang-cl to compile, this rather important warning shows up:
```
object.c(1121,33):  warning: variable 'returnLength' may be uninitialized when used here [-Wconditional-uninitialized]
                *ReturnLength = returnLength;
                                ^~~~~~~~~~~~
object.c(584,23):  note: initialize the variable 'returnLength' to silence this warning
    ULONG returnLength;
                      ^
                       = 0
```

Hence initialise to zero.