### PR TITLE
Another 'uninitialized' warning from clang-cl

### DIFF
--- a/KProcessHacker/vm.c
+++ b/KProcessHacker/vm.c
@@ -323,7 +323,7 @@ NTSTATUS KpiReadVirtualMemoryUnsafe(
 {
     NTSTATUS status;
     PEPROCESS process;
-    SIZE_T numberOfBytesRead;
+    SIZE_T numberOfBytesRead = 0;
 
     PAGED_CODE();
 


### PR DESCRIPTION
clang-cl warning was:
```
vm.c(434,38):  warning: variable 'numberOfBytesRead' may be uninitialized when used here [-Wconditional-uninitialized]
                *NumberOfBytesRead = numberOfBytesRead;
                                     ^~~~~~~~~~~~~~~~~
vm.c(326,29):  note: initialize the variable 'numberOfBytesRead' to silence this warning
    SIZE_T numberOfBytesRead;
                            ^
```
Simply initialise to zero to fix.