### PR TITLE
Add .editorconfig file

### DIFF
--- a/.editorconfig
+++ b/.editorconfig
@@ -1,0 +1,7 @@
+root=true
+
+[*]
+indent_style=space
+indent_size=4
+trim_trailing_whitespace=true
+insert_final_newline=true


### PR DESCRIPTION
VS2017 finally supports [.editorconfig](https://docs.microsoft.com/en-us/visualstudio/ide/create-portable-custom-editor-options) file that can be used to enforce coding consistency.

It is especially useful for people that contribute to more projects, while each project uses different indent style (tab vs spaces, tab size).
`.editorconfig` file overrides VS editor settings, so that there is no need to adjust them when switching between projects.