### PR TITLE
Fix RtlOsDeploymentState declaration.

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -8026,14 +8026,14 @@ RtlConvertDeviceFamilyInfoToString(
     _Out_writes_bytes_(*DeviceFormBufferSize) PWSTR DeviceForm
     );
 
-#endif
-
 NTSYSAPI
 OS_DEPLOYEMENT_STATE_VALUES
 NTAPI
 RtlOsDeploymentState(
     _Reserved_ _In_ ULONG Flags
     );
+
+#endif
 
 #if (PHNT_VERSION >= PHNT_VISTA)
 


### PR DESCRIPTION
I moved the declaration for `RtlOsDeploymentState` into the #if block above it that checks if `PHNT_VERSION >= PHNT_THRESHOLD`, because it causes this compilation error otherwise:

```
ntrtl.h(8033): error C2143: syntax error: missing '{' before '__cdecl'
```

This is due to its return type `OS_DEPLOYEMENT_STATE_VALUES` not being declared in `winnt.h` unless `NTDDI_VERSION >= NTDDI_WINTHRESHOLD`. 

`RtlOsDeploymentState` also does not exist on previous Windows anyway, so should be in the #if block regardless.