### PR TITLE
Cast const empty string to PWSTR

### DIFF
--- a/phlib/include/phbasesup.h
+++ b/phlib/include/phbasesup.h
@@ -1331,7 +1331,7 @@ PhGetStringOrEmpty(
     if (String)
         return String->Buffer;
     else
-        return L"";
+        return (PWSTR)L"";
 }
 
 /**


### PR DESCRIPTION
`Error C2440 'return': cannot convert from 'const wchar_t [1]' to 'PWSTR'`

I don't think the error/warning is reproducible since it probably would've been noticed already...