### PR TITLE
Support listing process DPI awareness on pre-8.1 Windows versions.

### DIFF
--- a/ProcessHacker/cmdmode.c
+++ b/ProcessHacker/cmdmode.c
@@ -24,12 +24,6 @@
 
 #include <svcsup.h>
 
-NTSTATUS PhpGetDllBaseRemote(
-    _In_ HANDLE ProcessHandle,
-    _In_ PPH_STRINGREF BaseDllName,
-    _Out_ PVOID *DllBase
-    );
-
 static HWND CommandModeWindowHandle;
 
 #define PH_COMMAND_OPTION_HWND 1
@@ -339,61 +333,6 @@ NTSTATUS PhCommandModeStart(
             }
         }
     }
-
-    return status;
-}
-
-typedef struct _GET_DLL_BASE_REMOTE_CONTEXT
-{
-    PH_STRINGREF BaseDllName;
-    PVOID DllBase;
-} GET_DLL_BASE_REMOTE_CONTEXT, *PGET_DLL_BASE_REMOTE_CONTEXT;
-
-static BOOLEAN PhpGetDllBaseRemoteCallback(
-    _In_ PLDR_DATA_TABLE_ENTRY Module,
-    _In_opt_ PVOID Context
-    )
-{
-    PGET_DLL_BASE_REMOTE_CONTEXT context = Context;
-    PH_STRINGREF baseDllName;
-
-    PhUnicodeStringToStringRef(&Module->BaseDllName, &baseDllName);
-
-    if (PhEqualStringRef(&baseDllName, &context->BaseDllName, TRUE))
-    {
-        context->DllBase = Module->DllBase;
-        return FALSE;
-    }
-
-    return TRUE;
-}
-
-NTSTATUS PhpGetDllBaseRemote(
-    _In_ HANDLE ProcessHandle,
-    _In_ PPH_STRINGREF BaseDllName,
-    _Out_ PVOID *DllBase
-    )
-{
-    NTSTATUS status;
-    GET_DLL_BASE_REMOTE_CONTEXT context;
-#ifdef _WIN64
-    BOOLEAN isWow64 = FALSE;
-#endif
-
-    context.BaseDllName = *BaseDllName;
-    context.DllBase = NULL;
-
-#ifdef _WIN64
-    PhGetProcessIsWow64(ProcessHandle, &isWow64);
-
-    if (isWow64)
-        status = PhEnumProcessModules32(ProcessHandle, PhpGetDllBaseRemoteCallback, &context);
-    if (!context.DllBase)
-#endif
-        status = PhEnumProcessModules(ProcessHandle, PhpGetDllBaseRemoteCallback, &context);
-
-    if (NT_SUCCESS(status))
-        *DllBase = context.DllBase;
 
     return status;
 }

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -656,6 +656,15 @@ PhGetProcedureAddressRemote(
 PHLIBAPI
 NTSTATUS
 NTAPI
+PhGetDllBaseRemote(
+    _In_ HANDLE ProcessHandle,
+    _In_ PPH_STRINGREF BaseDllName,
+    _Out_ PVOID *DllBase
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
 PhEnumKernelModules(
     _Out_ PRTL_PROCESS_MODULES *Modules
     );


### PR DESCRIPTION
Here is my proposal for fixing #309. 

~~It currently mostly works, but there is an issue with getting information from processes started after process hacker - I think it might be because the information is being read too soon.~~

Fixes #309. Fixes #313.