### PR TITLE
Invalidate dpi awareness if Unaware as it may change.

### DIFF
--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -642,11 +642,19 @@ VOID PhTickProcessNodes(
 
     for (i = 0; i < ProcessNodeList->Count; i++)
     {
+        ULONG remainsValidMask;
         PPH_PROCESS_NODE node = ProcessNodeList->Items[i];
 
         // The name and PID never change, so we don't invalidate that.
         memset(&node->TextCache[2], 0, sizeof(PH_STRINGREF) * (PHPRTLC_MAXIMUM - 2));
-        node->ValidMask &= PHPN_OSCONTEXT | PHPN_IMAGE | PHPN_DPIAWARENESS | PHPN_APPID | PHPN_DESKTOPINFO | PHPN_USERNAME; // Items that always remain valid
+
+        remainsValidMask = PHPN_OSCONTEXT | PHPN_IMAGE | PHPN_APPID | PHPN_DESKTOPINFO | PHPN_USERNAME; // Items that always remain valid
+        // The DPI awareness defaults to unaware if not set or declared in the manifest in which case
+        // it can be changed once, so we can only be sure that it won't be changed again if it is different
+        // from Unaware.
+        if (node->DpiAwareness != 1)
+            remainsValidMask |= PHPN_DPIAWARENESS;
+        node->ValidMask &= remainsValidMask;
 
         // Invalidate graph buffers.
         node->CpuGraphBuffers.Valid = FALSE;


### PR DESCRIPTION
Fixes #313

@dmex So it only keeps the PHPN_DPIAWARENESS flag in PhTickProcessNodes if it is different from unaware as it might change if it is unaware because it hasn't been set explicitly.

Btw. I'm not a fan of the magic numbers for DpiAwareness, could we add constants or change it into an enum?