### PR TITLE
Adjustment of groups for tokens

### DIFF
--- a/ProcessHacker/resource.h
+++ b/ProcessHacker/resource.h
@@ -741,6 +741,10 @@
 #define ID_MINIINFO_REFRESHAUTOMATICALLY 40289
 #define IDC_MAXSCREEN                   40293
 #define ID_EMPTY_COMBINEMEMORYLISTS     40295
+#define ID_PRIVILEGE_RESET              40296
+#define ID_GROUP_ENABLE                 40297
+#define ID_GROUP_DISABLE                40298
+#define ID_GROUP_RESET                  40299
 #define IDDYNAMIC                       50000
 #define IDPLUGINS                       55000
 

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -440,7 +440,7 @@ PhSetTokenPrivilege2(
     );
 
 PHLIBAPI
-BOOLEAN
+NTSTATUS
 NTAPI
 PhSetTokenGroups(
     _In_ HANDLE TokenHandle,

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -2213,7 +2213,17 @@ BOOLEAN PhSetTokenPrivilege2(
     return PhSetTokenPrivilege(TokenHandle, NULL, &privilegeLuid, Attributes);
 }
 
-BOOLEAN PhSetTokenGroups(
+/**
+* Modifies a token group.
+*
+* \param TokenHandle A handle to a token. The handle must have TOKEN_ADJUST_GROUPS access.
+* \param GroupName The name of the group to modify. If this parameter is NULL, you must
+* specify a PSID in the \a GroupSid parameter.
+* \param GroupSid The PSID of the group to modify. If this parameter is NULL, you must
+* specify a group name in the \a GroupName parameter.
+* \param Attributes The new attributes of the group.
+*/
+NTSTATUS PhSetTokenGroups(
     _In_ HANDLE TokenHandle,
     _In_opt_ PWSTR GroupName,
     _In_opt_ PSID GroupSid,
@@ -2237,11 +2247,11 @@ BOOLEAN PhSetTokenGroups(
         PhInitializeStringRef(&groupName, GroupName);
 
         if (!NT_SUCCESS(status = PhLookupName(&groupName, &groups.Groups[0].Sid, NULL, NULL)))
-            return FALSE;
+            return status;
     }
     else
     {
-        return FALSE;
+        return STATUS_INVALID_PARAMETER;
     }
 
     if (!NT_SUCCESS(status = NtAdjustGroupsToken(
@@ -2262,13 +2272,13 @@ BOOLEAN PhSetTokenGroups(
     if (GroupName && groups.Groups[0].Sid)
         PhFree(groups.Groups[0].Sid);
 
-    return TRUE;
+    return status;
 
 CleanupExit:
     if (GroupName && groups.Groups[0].Sid)
         PhFree(groups.Groups[0].Sid);
 
-    return FALSE;
+    return status;
 }
 
 /**


### PR DESCRIPTION
I've implemented resetting of privileges and adjusting of groups in tokens. Besides this, I've moved all restricting SIDs to a separate category since they can't be modified and are treated by the OS as the second group list that can contain arbitrary entries (not necessarily corresponding to token groups).