### PR TITLE
Improve search of memory regions

### DIFF
--- a/ProcessHacker/prpgmem.c
+++ b/ProcessHacker/prpgmem.c
@@ -261,13 +261,32 @@ BOOLEAN PhpMemoryTreeFilterCallback(
     if (PhIsNullOrEmptyString(memoryContext->SearchboxText))
         return TRUE;
 
-    if (
-        memoryContext->UseSearchPointer && 
-        (memoryNode->MemoryItem->BaseAddress == (PVOID)memoryContext->SearchPointer ||
-        memoryNode->MemoryItem->AllocationBase == (PVOID)memoryContext->SearchPointer)
-        )
+    if (memoryContext->UseSearchPointer)
     {
-        return TRUE;
+        // Show all the nodes for which the specified pointer is the allocation base
+        if ((ULONG64)memoryNode->MemoryItem->AllocationBase == memoryContext->SearchPointer)
+        {
+            return TRUE;
+        }
+
+        // Show the AllocationBaseNode for which the specified pointer is within its range
+        if (
+            memoryNode->IsAllocationBase &&
+            (ULONG64)memoryNode->MemoryItem->AllocationBase <= memoryContext->SearchPointer &&
+            (ULONG64)memoryNode->MemoryItem->AllocationBase + (ULONG64)memoryNode->MemoryItem->RegionSize > memoryContext->SearchPointer
+            )
+        {
+            return TRUE;
+        }
+
+        // Show the RegionNode for which the specified pointer is within its range
+        if (
+            (ULONG64)memoryNode->MemoryItem->BaseAddress <= memoryContext->SearchPointer &&
+            (ULONG64)memoryNode->MemoryItem->BaseAddress + (ULONG64)memoryNode->MemoryItem->RegionSize > memoryContext->SearchPointer
+            )
+        {
+            return TRUE;
+        }
     }
 
     if (memoryNode->BaseAddressText[0])


### PR DESCRIPTION
I've slightly changed the search algorithm used in the Memory page. Now it can handle arbitrary pointers and show you the region to which this pointer belongs.