### PR TITLE
 Show dangerous flags for tokens

### DIFF
--- a/ProcessHacker/resource.h
+++ b/ProcessHacker/resource.h
@@ -750,6 +750,7 @@
 #define ID_GROUP_RESET                  40299
 #define ID_TOOLS_SCM_PERMISSIONS        40300
 #define ID_TOOLS_RDP_PERMISSIONS        40301
+#define ID_UIACCESS_REMOVE              40302
 #define IDDYNAMIC                       50000
 #define IDPLUGINS                       55000
 

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -629,7 +629,7 @@ BOOLEAN PhpUpdateTokenDangerousFlags(
                 PH_PROCESS_TOKEN_FLAG_NO_WRITE_UP,
                 FALSE,
                 L"No-Write-Up Policy",
-                L"Prevents the process from modifying objects with higher integrity"
+                L"Prevents the process from modifying objects with a higher integrity"
                 );
         }
     }

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -32,7 +32,7 @@
 #include <phsettings.h>
 
 typedef enum _PH_PROCESS_TOKEN_CATEGORY
-{    
+{
     PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES,
     PH_PROCESS_TOKEN_CATEGORY_GROUPS,
     PH_PROCESS_TOKEN_CATEGORY_RESTRICTED,
@@ -360,7 +360,7 @@ static COLORREF NTAPI PhpTokenGroupColorFunction(
     if (entry->ItemCategory == PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS)
         return PhGetDangerousFlagColor(entry->ItemFlagState);
     else if (entry->ItemCategory == PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES)
-        return PhGetPrivilegeAttributesColor(entry->TokenPrivilege->Attributes);    
+        return PhGetPrivilegeAttributesColor(entry->TokenPrivilege->Attributes);
     else
         return PhGetGroupAttributesColor(entry->TokenGroup->Attributes);
 }
@@ -448,10 +448,10 @@ VOID PhpUpdateSidsFromTokenGroups(
             lvitem->TokenGroup = &Groups->Groups[i];
 
             lvItemIndex = PhAddListViewGroupItem(
-                ListViewHandle, 
+                ListViewHandle,
                 lvitem->ItemCategory,
-                PH_PROCESS_TOKEN_INDEX_NAME, 
-                fullName->Buffer, 
+                PH_PROCESS_TOKEN_INDEX_NAME,
+                fullName->Buffer,
                 lvitem
                 );
 
@@ -472,7 +472,7 @@ VOID PhpUpdateSidsFromTokenGroups(
                 PhSetListViewSubItem(ListViewHandle, lvItemIndex, PH_PROCESS_TOKEN_INDEX_DESCRIPTION, PhGetString(descriptionString));
                 PhDereferenceObject(descriptionString);
             }
-      
+
             PhDereferenceObject(fullName);
         }
     }
@@ -615,7 +615,7 @@ BOOLEAN PhpUpdateTokenDangerousFlags(
     _In_ HANDLE TokenHandle
     )
 {
-    TOKEN_MANDATORY_POLICY mandatoryPolicy;    
+    TOKEN_MANDATORY_POLICY mandatoryPolicy;
     BOOLEAN isSandboxInert;
     BOOLEAN isUIAccess;
 
@@ -632,7 +632,7 @@ BOOLEAN PhpUpdateTokenDangerousFlags(
                 L"Prevents the process from modifying objects with higher integrity"
                 );
         }
-    }    
+    }
 
     if (NT_SUCCESS(PhGetTokenIsSandBoxInert(TokenHandle, &isSandboxInert)))
     {
@@ -663,7 +663,7 @@ BOOLEAN PhpUpdateTokenDangerousFlags(
                 );
         }
     }
-    
+
     return TRUE;
 }
 
@@ -795,7 +795,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         if (appContainerInfo->TokenAppContainer)
                         {
                             appContainerName = PhGetAppContainerName(appContainerInfo->TokenAppContainer);
-                            appContainerSid = PhSidToStringSid(appContainerInfo->TokenAppContainer);    
+                            appContainerSid = PhSidToStringSid(appContainerInfo->TokenAppContainer);
                         }
 
                         PhFree(appContainerInfo);
@@ -1015,7 +1015,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         PhShowStatus(hwndDlg, L"Unable to open the token.", status, 0);
                     }
 
-                    PhFree(listViewItems);                                                            
+                    PhFree(listViewItems);
                 }
                 break;
             case ID_GROUP_ENABLE:
@@ -1094,7 +1094,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                                     tokenPageContext->ListViewHandle,
                                     -1,
                                     listViewItems[i]
-                                    );                                
+                                    );
 
                                 // Refresh the status text (and background color).
                                 listViewItems[i]->TokenGroup->Attributes = newAttributes;
@@ -1158,7 +1158,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         &listViewItems,
                         &numberOfItems
                         );
-      
+
                     if (numberOfItems != 1)
                     {
                         PhFree(listViewItems);
@@ -1209,12 +1209,12 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         }
                         else
                         {
-                            PhShowStatus(hwndDlg, L"Unable to disable UIAccess flag.", status, 0);                         
+                            PhShowStatus(hwndDlg, L"Unable to disable UIAccess flag.", status, 0);
                         }
 
                         ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
                         ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, TRUE);
-                       
+
                         NtClose(tokenHandle);
                     }
                     else
@@ -1311,7 +1311,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                             if (customLevelPosition)
                             {
                                 PPH_EMENU_ITEM unknownIntegrityItem;
-                                
+
                                 unknownIntegrityItem = PhCreateEMenuItem(0, (ULONG)integrityLevelRID, L"Intermediate level", NULL, NULL);
                                 unknownIntegrityItem->Flags |= PH_EMENU_CHECKED | PH_EMENU_RADIOCHECK;
                                 PhInsertEMenuItem(menu, unknownIntegrityItem, customLevelPosition);

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -32,11 +32,19 @@
 #include <phsettings.h>
 
 typedef enum _PH_PROCESS_TOKEN_CATEGORY
-{
+{    
     PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES,
     PH_PROCESS_TOKEN_CATEGORY_GROUPS,
-    PH_PROCESS_TOKEN_CATEGORY_RESTRICTED
+    PH_PROCESS_TOKEN_CATEGORY_RESTRICTED,
+    PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS
 } PH_PROCESS_TOKEN_CATEGORY;
+
+typedef enum _PH_PROCESS_TOKEN_FLAG
+{
+    PH_PROCESS_TOKEN_FLAG_NO_WRITE_UP,
+    PH_PROCESS_TOKEN_FLAG_SANDBOX_INERT,
+    PH_PROCESS_TOKEN_FLAG_UIACCESS
+} PH_PROCESS_TOKEN_FLAG;
 
 typedef enum _PH_PROCESS_TOKEN_INDEX
 {
@@ -52,6 +60,11 @@ typedef struct _PHP_TOKEN_PAGE_LISTVIEW_ITEM
     {
         PSID_AND_ATTRIBUTES TokenGroup;
         PLUID_AND_ATTRIBUTES TokenPrivilege;
+        struct
+        {
+            PH_PROCESS_TOKEN_FLAG ItemFlag;
+            BOOLEAN ItemFlagState;
+        };
     };
 } PHP_TOKEN_PAGE_LISTVIEW_ITEM, *PPHP_TOKEN_PAGE_LISTVIEW_ITEM;
 
@@ -326,6 +339,16 @@ COLORREF PhGetPrivilegeAttributesColor(
     }
 }
 
+COLORREF PhGetDangerousFlagColor(
+    _In_ BOOLEAN FlagState
+)
+{
+    if (FlagState)
+        return RGB(0xc0, 0xf0, 0xc0);
+    else
+        return RGB(0xf0, 0xc0, 0xc0);
+}
+
 static COLORREF NTAPI PhpTokenGroupColorFunction(
     _In_ INT Index,
     _In_ PVOID Param,
@@ -334,8 +357,10 @@ static COLORREF NTAPI PhpTokenGroupColorFunction(
 {
     PPHP_TOKEN_PAGE_LISTVIEW_ITEM entry = Param;
 
-    if (entry->ItemCategory == PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES)
-        return PhGetPrivilegeAttributesColor(entry->TokenPrivilege->Attributes);
+    if (entry->ItemCategory == PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS)
+        return PhGetDangerousFlagColor(entry->ItemFlagState);
+    else if (entry->ItemCategory == PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES)
+        return PhGetPrivilegeAttributesColor(entry->TokenPrivilege->Attributes);    
     else
         return PhGetGroupAttributesColor(entry->TokenGroup->Attributes);
 }
@@ -513,6 +538,7 @@ BOOLEAN PhpUpdateTokenPrivileges(
             PPHP_TOKEN_PAGE_LISTVIEW_ITEM lvitem;
 
             lvitem = PhAllocateZero(sizeof(PHP_TOKEN_PAGE_LISTVIEW_ITEM));
+            lvitem->ItemCategory = PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES;
             lvitem->TokenPrivilege = &privileges->Privileges[i];
 
             privilegeDisplayName = NULL;
@@ -541,6 +567,103 @@ BOOLEAN PhpUpdateTokenPrivileges(
 
     TokenPageContext->Privileges = privileges;
 
+    return TRUE;
+}
+
+VOID PhpUpdateTokenDangerousFlagItem(
+    _In_ HWND ListViewHandle,
+    _In_ PH_PROCESS_TOKEN_FLAG Flag,
+    _In_ BOOLEAN State,
+    _In_ PWSTR Name,
+    _In_ PWSTR Description
+    )
+{
+    INT lvItemIndex;
+    PPHP_TOKEN_PAGE_LISTVIEW_ITEM lvitem;
+
+    lvitem = PhAllocateZero(sizeof(PHP_TOKEN_PAGE_LISTVIEW_ITEM));
+    lvitem->ItemCategory = PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS;
+    lvitem->ItemFlag = Flag;
+    lvitem->ItemFlagState = State;
+
+    lvItemIndex = PhAddListViewGroupItem(
+        ListViewHandle,
+        lvitem->ItemCategory,
+        PH_PROCESS_TOKEN_INDEX_NAME,
+        Name,
+        lvitem
+        );
+
+    PhSetListViewSubItem(ListViewHandle,
+        lvItemIndex,
+        PH_PROCESS_TOKEN_INDEX_STATUS,
+        State ? L"Enabled (modified)" : L"Disabled (modified)"
+        );
+
+    PhSetListViewSubItem(
+        ListViewHandle,
+        lvItemIndex,
+        PH_PROCESS_TOKEN_INDEX_DESCRIPTION,
+        Description
+        );
+}
+
+BOOLEAN PhpUpdateTokenDangerousFlags(
+    _In_ HWND hwndDlg,
+    _In_ PTOKEN_PAGE_CONTEXT TokenPageContext,
+    _In_ HWND ListViewHandle,
+    _In_ HANDLE TokenHandle
+    )
+{
+    TOKEN_MANDATORY_POLICY mandatoryPolicy;    
+    BOOLEAN isSandboxInert;
+    BOOLEAN isUIAccess;
+
+    if (NT_SUCCESS(PhGetTokenMandatoryPolicy(TokenHandle, &mandatoryPolicy)))
+    {
+        // The disabled no-write-up policy is considered to be dangerous (diversenok)
+        if ((mandatoryPolicy.Policy & TOKEN_MANDATORY_POLICY_NO_WRITE_UP) == 0)
+        {
+            PhpUpdateTokenDangerousFlagItem(
+                ListViewHandle,
+                PH_PROCESS_TOKEN_FLAG_NO_WRITE_UP,
+                FALSE,
+                L"No-Write-Up Policy",
+                L"Prevents the process from modifying objects with higher integrity"
+                );
+        }
+    }    
+
+    if (NT_SUCCESS(PhGetTokenIsSandBoxInert(TokenHandle, &isSandboxInert)))
+    {
+        // The presence of SandboxInert flag is considered dangerous (diversenok)
+        if (isSandboxInert)
+        {
+            PhpUpdateTokenDangerousFlagItem(
+                ListViewHandle,
+                PH_PROCESS_TOKEN_FLAG_SANDBOX_INERT,
+                TRUE,
+                L"Sandbox Inert",
+                L"Ignore AppLocker rules and Software Restriction Policies"
+                );
+        }
+    }
+
+    if (NT_SUCCESS(PhGetTokenIsUIAccessEnabled(TokenHandle, &isUIAccess)))
+    {
+        // The presence of UIAccess flag is considered dangerous (diversenok)
+        if (isUIAccess)
+        {
+            PhpUpdateTokenDangerousFlagItem(
+                ListViewHandle,
+                PH_PROCESS_TOKEN_FLAG_UIACCESS,
+                TRUE,
+                L"UIAccess",
+                L"Ignore User Interface Privilege Isolation"
+                );
+        }
+    }
+    
     return TRUE;
 }
 
@@ -592,6 +715,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
             PhSetExtendedListView(tokenPageContext->ListViewHandle);
             ExtendedListView_SetItemColorFunction(tokenPageContext->ListViewHandle, PhpTokenGroupColorFunction);
             ListView_EnableGroupView(tokenPageContext->ListViewHandle, TRUE);
+            PhAddListViewGroup(tokenPageContext->ListViewHandle, PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS, L"Dangerous Flags");
             PhAddListViewGroup(tokenPageContext->ListViewHandle, PH_PROCESS_TOKEN_CATEGORY_PRIVILEGES, L"Privileges");
             PhAddListViewGroup(tokenPageContext->ListViewHandle, PH_PROCESS_TOKEN_CATEGORY_GROUPS, L"Groups");
             PhAddListViewGroup(tokenPageContext->ListViewHandle, PH_PROCESS_TOKEN_CATEGORY_RESTRICTED, L"Restricting SIDs");
@@ -698,6 +822,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                 ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, FALSE);
                 PhpTokenPageFreeListViewEntries(tokenPageContext);
                 ListView_DeleteAllItems(tokenPageContext->ListViewHandle);
+                PhpUpdateTokenDangerousFlags(hwndDlg, tokenPageContext, tokenPageContext->ListViewHandle, tokenHandle);
                 PhpUpdateTokenGroups(hwndDlg, tokenPageContext, tokenPageContext->ListViewHandle, tokenHandle);
                 PhpUpdateTokenPrivileges(hwndDlg, tokenPageContext, tokenPageContext->ListViewHandle, tokenHandle);
                 ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
@@ -771,7 +896,10 @@ INT_PTR CALLBACK PhpTokenPageProc(
                             L"and is permanent for the lifetime of the process.",
                             FALSE
                             ))
+                        {
+                            PhFree(listViewItems);
                             break;
+                        }
                     }
 
                     status = tokenPageContext->OpenObject(
@@ -877,6 +1005,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                             }
                         }
 
+                        ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
                         ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, TRUE);
 
                         NtClose(tokenHandle);
@@ -886,9 +1015,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                         PhShowStatus(hwndDlg, L"Unable to open the token.", status, 0);
                     }
 
-                    PhFree(listViewItems);
-
-                    ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
+                    PhFree(listViewItems);                                                            
                 }
                 break;
             case ID_GROUP_ENABLE:
@@ -1006,6 +1133,7 @@ INT_PTR CALLBACK PhpTokenPageProc(
                             }
                         }
 
+                        ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
                         ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, TRUE);
 
                         NtClose(tokenHandle);
@@ -1016,8 +1144,85 @@ INT_PTR CALLBACK PhpTokenPageProc(
                     }
 
                     PhFree(listViewItems);
+                }
+                break;
+            case ID_UIACCESS_REMOVE:
+                {
+                    NTSTATUS status;
+                    PPHP_TOKEN_PAGE_LISTVIEW_ITEM *listViewItems;
+                    ULONG numberOfItems;
+                    HANDLE tokenHandle;
 
-                    ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
+                    PhGetSelectedListViewItemParams(
+                        tokenPageContext->ListViewHandle,
+                        &listViewItems,
+                        &numberOfItems
+                        );
+      
+                    if (numberOfItems != 1)
+                    {
+                        PhFree(listViewItems);
+                        break;
+                    }
+
+                    if ((listViewItems[0]->ItemCategory != PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS) ||
+                        (listViewItems[0]->ItemFlag != PH_PROCESS_TOKEN_FLAG_UIACCESS))
+                    {
+                        PhFree(listViewItems);
+                        break;
+                    }
+
+                    if (!PhShowConfirmMessage(
+                        hwndDlg,
+                        L"remove",
+                        L"the UIAccess flag",
+                        L"Removing this flag may reduce the functionality of the process "
+                        L"provided it is an accessibility application.",
+                        FALSE
+                        ))
+                    {
+                        PhFree(listViewItems);
+                        break;
+                    }
+
+                    status = tokenPageContext->OpenObject(
+                        &tokenHandle,
+                        TOKEN_ADJUST_DEFAULT,
+                        tokenPageContext->Context
+                        );
+
+                    if (NT_SUCCESS(status))
+                    {
+                        ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, FALSE);
+
+                        status = PhSetTokenUIAccessEnabled(tokenHandle, FALSE);
+
+                        if (NT_SUCCESS(status))
+                        {
+                            INT lvItemIndex = PhFindListViewItemByParam(
+                                tokenPageContext->ListViewHandle,
+                                -1,
+                                listViewItems[0]
+                                );
+
+                            ListView_DeleteItem(tokenPageContext->ListViewHandle, lvItemIndex);
+                        }
+                        else
+                        {
+                            PhShowStatus(hwndDlg, L"Unable to disable UIAccess flag.", status, 0);                         
+                        }
+
+                        ExtendedListView_SortItems(tokenPageContext->ListViewHandle);
+                        ExtendedListView_SetRedraw(tokenPageContext->ListViewHandle, TRUE);
+                       
+                        NtClose(tokenHandle);
+                    }
+                    else
+                    {
+                        PhShowStatus(hwndDlg, L"Unable to open the token.", status, 0);
+                    }
+
+                    PhFree(listViewItems);
                 }
                 break;
             case ID_PRIVILEGE_COPY:
@@ -1269,6 +1474,12 @@ INT_PTR CALLBACK PhpTokenPageProc(
                                 PhInsertEMenuItem(menu, PhCreateEMenuItem(0, ID_GROUP_DISABLE, L"&Disable", NULL, NULL), ULONG_MAX);
                                 PhInsertEMenuItem(menu, PhCreateEMenuItem(0, ID_GROUP_RESET, L"Re&set", NULL, NULL), ULONG_MAX);
                                 PhInsertEMenuItem(menu, PhCreateEMenuSeparator(), ULONG_MAX);
+                            }
+                            break;
+                        case PH_PROCESS_TOKEN_CATEGORY_DANGEROUS_FLAGS:
+                            {
+                                if ((numberOfItems == 1) && (listviewItems[0]->ItemFlag == PH_PROCESS_TOKEN_FLAG_UIACCESS))
+                                    PhInsertEMenuItem(menu, PhCreateEMenuItem(0, ID_UIACCESS_REMOVE, L"&Remove", NULL, NULL), ULONG_MAX);
                             }
                             break;
                         }

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -1334,6 +1334,13 @@ PhGetTokenIsUIAccessEnabled(
     return status;
 }
 
+/**
+* Sets UIAccess flag for a token.
+*
+* \param TokenHandle A handle to a token. The handle must have TOKEN_ADJUST_DEFAULT access.
+* \param IsUIAccessEnabled The new flag state.
+* \remarks Enabling UIAccess requires SeTcbPrivilege.
+*/
 FORCEINLINE
 NTSTATUS
 PhSetTokenUIAccessEnabled(
@@ -1384,6 +1391,34 @@ PhGetTokenIsSandBoxInert(
 
     *IsSandBoxInert = !!sandBoxInert;
 
+    return status;
+}
+
+/**
+* Gets Mandatory Policy for a token.
+*
+* \param TokenHandle A handle to a token. The handle must have TOKEN_QUERY access.
+* \param MandatoryPolicy A variable which receives a set of mandatory integrity
+* policies enforced for the token.
+*/
+FORCEINLINE
+NTSTATUS
+PhGetTokenMandatoryPolicy(
+    _In_ HANDLE TokenHandle,
+    _Out_ PTOKEN_MANDATORY_POLICY MandatoryPolicy
+    )
+{
+    NTSTATUS status;
+    ULONG returnLength;
+
+    status = NtQueryInformationToken(
+        TokenHandle,
+        TokenMandatoryPolicy,
+        MandatoryPolicy,
+        sizeof(TOKEN_MANDATORY_POLICY),
+        &returnLength
+        );
+    
     return status;
 }
 


### PR DESCRIPTION
I've implemented a category of dangerous flags that might present in a token:
 - Disabled No-Write-Up policy that normally prevents the modification of objects with a higher integrity;
 - Enabled Sandbox Inert flag that disables AppLocker and SRP rules for the process;
 - Enabled UIAccess flag that allows it to bypass UIPI to perform shatter attacks or keylogging.

The last one can also be disabled now via the context menu while the first two can't be disabled at all (as I know).

![dangerous-flags](https://user-images.githubusercontent.com/30962924/48629047-a7efa980-e9c9-11e8-8d32-dff50f1664d2.png)

The work of UIAccess flag can be tested on accessibility applications (like onscreen keyboard) that use it to send messages to windows with a higher integrity.