### PR TITLE
Correct token mandatory label interpretation

### DIFF
--- a/phlib/native.c
+++ b/phlib/native.c
@@ -2321,6 +2321,7 @@ NTSTATUS PhGetTokenIntegrityLevelRID(
 {
     NTSTATUS status;
     PTOKEN_MANDATORY_LABEL mandatoryLabel;
+    ULONG subAuthoritiesCount;
     ULONG subAuthority;
     PWSTR integrityString;
 
@@ -2329,7 +2330,17 @@ NTSTATUS PhGetTokenIntegrityLevelRID(
     if (!NT_SUCCESS(status))
         return status;
 
-    subAuthority = *RtlSubAuthoritySid(mandatoryLabel->Label.Sid, 0);
+    subAuthoritiesCount = *RtlSubAuthorityCountSid(mandatoryLabel->Label.Sid);
+
+    if (subAuthoritiesCount > 0)
+    {
+        subAuthority = *RtlSubAuthoritySid(mandatoryLabel->Label.Sid, subAuthoritiesCount - 1);
+    }
+    else
+    {
+        subAuthority = SECURITY_MANDATORY_UNTRUSTED_RID;
+    }
+
     PhFree(mandatoryLabel);
 
     if (IntegrityString)


### PR DESCRIPTION
As it turned out, it is possible to create valid tokens with a mandatory label SID of an arbitrary length (like `S-1-16-0-0-0-8192`). So, we should interpret them as the OS does: consider the last sub-authority as an integrity level.

This behavior can be spotted, for example, by checking what `NtSetInformationToken` does when it changes the integrity level. And, also, how programs with such tokens act against mandatory access control checks.