### PR TITLE
Add support for environment variables starting with equality sign

### DIFF
--- a/ProcessHacker/include/procprpp.h
+++ b/ProcessHacker/include/procprpp.h
@@ -347,7 +347,9 @@ typedef struct _PH_ENVIRONMENT_CONTEXT
             ULONG HighlightProcessEnvironment : 1;
             ULONG HighlightUserEnvironment : 1;
             ULONG HighlightSystemEnvironment : 1;
-            ULONG Spare : 25;
+            ULONG HideSubstitutionEnvironment : 1;
+            ULONG HighlightSubstitutionEnvironment : 1;
+            ULONG Spare : 23;
         };
     };
 

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -1063,8 +1063,8 @@ BOOLEAN PhEnumProcessEnvironmentVariables(
     {
         if (currentIndex >= length)
             return FALSE;
-        if (*currentChar == '=')
-            break;
+        if ((*currentChar == '=') && (startIndex != currentIndex))
+            break; // equality sign is considered as a delimiter unless it is the first character (diversenok)
         if (*currentChar == 0)
             return FALSE; // no more variables
 


### PR DESCRIPTION
In spite of the fact that WinAPI documentation states that the name of an environment variable can't contain an equality sign, it's not entirely true. The name can start with it. Actually, both `GetEnvironmentVariable` and `SetEnvironmentVariable` work fine with such variables.  What about showing all of them in a separate category?

![substitutions](https://user-images.githubusercontent.com/30962924/51977615-eeb55180-2498-11e9-9ab0-a6280fbe4c5a.png)

I wasn't able to find out whether such class of variables has a particular name. So, I came up with calling them substitutions because of their only known application. These variables (the ones containing a drive letter) are used as current directories on a per-drive basis. They are mostly utilized by the Command Processor, but, actually, WinAPI takes them into account too. The following code will open `D:\Folder\file.txt` since `CreateFile` looks for an environment variable used as a label.

    SetEnvironmentVariable("=D:", "D:\Folder");
    CreateFile("D:file.txt", …)

Thus, sometimes it might be useful to view or change such variables for other processes.