### PR TITLE
Use HTTPS for Microsoft Symbol server URL

### DIFF
--- a/tools/peview/pdb.c
+++ b/tools/peview/pdb.c
@@ -2365,7 +2365,7 @@ NTSTATUS PeDumpFileSymbols(
     if (!SymInitializeW_I(NtCurrentProcess(), NULL, FALSE))
         return 1;
 
-    if (!SymSetSearchPathW_I(NtCurrentProcess(), L"SRV*C:\\symbols*http://msdl.microsoft.com/download/symbols"))
+    if (!SymSetSearchPathW_I(NtCurrentProcess(), L"SRV*C:\\symbols*https://msdl.microsoft.com/download/symbols"))
         goto CleanupExit;
 
     if (!NT_SUCCESS(status = PhCreateFileWin32(

--- a/tools/peview/peprp.c
+++ b/tools/peview/peprp.c
@@ -812,7 +812,7 @@ BOOLEAN PvpLoadDbgHelp(
     else
     {
         // Set the default path (C:\\Symbols is the default hard-coded path for livekd). 
-        symbolSearchPath = PhCreateString(L"SRV*C:\\Symbols*http://msdl.microsoft.com/download/symbols");
+        symbolSearchPath = PhCreateString(L"SRV*C:\\Symbols*https://msdl.microsoft.com/download/symbols");
     }
 
     PhSetSearchPathSymbolProvider(symbolProvider, symbolSearchPath->Buffer);


### PR DESCRIPTION
Microsoft now recommends using https://msdl.microsoft.com/download/symbols