### PR TITLE
Optimize SID translation

### DIFF
--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -429,19 +429,26 @@ VOID PhpUpdateSidsFromTokenGroups(
     )
 {
     ULONG i;
+    PSID *sids;
+    PPH_STRING *names = NULL;
+
+    sids = PhAllocate(sizeof(PSID) * Groups->GroupCount);
 
     for (i = 0; i < Groups->GroupCount; i++)
     {
-        INT lvItemIndex;
-        PPH_STRING fullName;
-        PPH_STRING attributesString;
-        PPH_STRING descriptionString;
+        sids[i] = Groups->Groups[i].Sid;
+    }
 
-        if (!(fullName = PhGetSidFullName(Groups->Groups[i].Sid, TRUE, NULL)))
-            fullName = PhSidToStringSid(Groups->Groups[i].Sid);
+    PhLookupSids(Groups->GroupCount, sids, &names);
+    PhFree(sids);
 
-        if (fullName)
+    for (i = 0; i < Groups->GroupCount; i++)
+    {
+        if (names[i])
         {
+            INT lvItemIndex;
+            PPH_STRING attributesString;
+            PPH_STRING descriptionString;
             PPHP_TOKEN_PAGE_LISTVIEW_ITEM lvitem;
 
             lvitem = PhAllocateZero(sizeof(PHP_TOKEN_PAGE_LISTVIEW_ITEM));
@@ -452,7 +459,7 @@ VOID PhpUpdateSidsFromTokenGroups(
                 ListViewHandle,
                 lvitem->ItemCategory,
                 PH_PROCESS_TOKEN_INDEX_NAME,
-                fullName->Buffer,
+                names[i]->Buffer,
                 lvitem
                 );
 
@@ -474,9 +481,11 @@ VOID PhpUpdateSidsFromTokenGroups(
                 PhDereferenceObject(descriptionString);
             }
 
-            PhDereferenceObject(fullName);
+            PhDereferenceObject(names[i]);
         }
     }
+
+    PhFree(names);
 }
 
 BOOLEAN PhpUpdateTokenGroups(

--- a/phlib/include/lsasup.h
+++ b/phlib/include/lsasup.h
@@ -56,6 +56,15 @@ PhLookupSid(
     );
 
 PHLIBAPI
+VOID
+NTAPI
+PhLookupSids(
+    _In_ ULONG Count,
+    _In_ PSID *Sids,
+    _Out_ PPH_STRING **FullNames
+    );
+
+PHLIBAPI
 NTSTATUS
 NTAPI
 PhLookupName(

--- a/phlib/lsasup.c
+++ b/phlib/lsasup.c
@@ -348,18 +348,18 @@ VOID PhLookupSids(
                 }
                 else if (domainName)
                 {
-                    translatedNames[i] = PhDuplicateString(domainName);
+                    translatedNames[i] = PhReferenceObject(domainName);
                 }
                 else if (userName)
                 {
-                    translatedNames[i] = PhDuplicateString(userName);
+                    translatedNames[i] = PhReferenceObject(userName);
                 }
             }
             else
             {
                 if (PhStartsWithString2(userName, L"S-1-", TRUE))
                 {
-                    translatedNames[i] = PhDuplicateString(userName);
+                    translatedNames[i] = PhReferenceObject(userName);
                 }
             }
 


### PR DESCRIPTION
I suppose we can (at least partially) solve the performance issue reported in #349 by replacing multiple queries to LSA with one request to translate all SIDs at once.