### PR TITLE
Don't prepend "Computer" when open key

### DIFF
--- a/ProcessHacker/appsup.c
+++ b/ProcessHacker/appsup.c
@@ -2074,7 +2074,7 @@ BOOLEAN PhShellOpenKey2(
     RtlInitUnicodeString(&valueName, favoriteName);
     PhUnicodeStringToStringRef(&valueName, &valueNameSr);
 
-    expandedKeyName = PhExpandKeyName(KeyName, TRUE);
+    expandedKeyName = PhExpandKeyName(KeyName, FALSE);
     NtSetValueKey(favoritesKeyHandle, &valueName, 0, REG_SZ, expandedKeyName->Buffer, (ULONG)expandedKeyName->Length + sizeof(UNICODE_NULL));
     PhDereferenceObject(expandedKeyName);
 

--- a/phlib/util.c
+++ b/phlib/util.c
@@ -3528,7 +3528,7 @@ VOID PhShellOpenKey(
         return;
 
     RtlInitUnicodeString(&valueName, L"LastKey");
-    lastKey = PhExpandKeyName(KeyName, TRUE);
+    lastKey = PhExpandKeyName(KeyName, FALSE);
     NtSetValueKey(regeditKeyHandle, &valueName, 0, REG_SZ, lastKey->Buffer, (ULONG)lastKey->Length + sizeof(UNICODE_NULL));
     PhDereferenceObject(lastKey);
 


### PR DESCRIPTION
When user clicks "Open key", the key name is prepended "Computer", but Regedit doesn't recognize "Computer" if the system locale is not English.

I found that at least on Windows 10 17763, there's no need to prepend "Computer\\". Regedit can open the correct key when the LastKey or Favorites values start with "HKEY_LOCAL_MACHINE", "HKEY_CURRENT_USER", etc.