### PR TITLE
Fix build error: _InterlockedExchange

### DIFF
--- a/ProcessHacker/actions.c
+++ b/ProcessHacker/actions.c
@@ -431,7 +431,7 @@ BOOLEAN PhUiConnectToPhSvcEx(
     {
         PhAcquireQueuedLockExclusive(&PhSvcStartLock);
 
-        if (_InterlockedExchange(PhSvcReferenceCount, 0) == 0)
+        if (_InterlockedExchange(&PhSvcReferenceCount, 0) == 0)
         {
             started = FALSE;
             PhpGetPhSvcPortName(Mode, &portName);


### PR DESCRIPTION
warning C4047: 'function': 'volatile long *' differs in levels of indirection from 'ULONG'