### PR TITLE
Mark terminated thread handles

### DIFF
--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -567,8 +567,19 @@ _Callback_ PPH_STRING PhStdGetClientIdName(
     {
         if (processInfo)
         {
+            PSYSTEM_THREAD_INFORMATION threadInfo = NULL;
+
+            for (ULONG i = 0; i < processInfo->NumberOfThreads; i++)
+            {
+                if (processInfo->Threads[i].ClientId.UniqueThread == ClientId->UniqueThread)
+                {
+                    threadInfo = &processInfo->Threads[i];
+                    break;
+                }
+            }
+
             name = PhFormatString(
-                L"%.*s (%lu): %lu",
+                threadInfo ? L"%.*s (%lu): %lu" : L"%.*s (%lu): non-existent thread %lu",
                 processInfo->ImageName.Length / sizeof(WCHAR),
                 processInfo->ImageName.Buffer,
                 HandleToUlong(ClientId->UniqueProcess),


### PR DESCRIPTION
Sometimes it is useful to determine who's leaking handles to terminated threads. I suggest labeling such handles in the same way as is already done for non-existent processes.

I also added exit status field into thread handle properties.

Remarks:
The best method for determining the existence of a thread is to search for it in the last process-thread snapshot. It fits perfectly to the implementation of `PhStdGetClientIdName`. However, I am not sure how to do it inside `PhGetClientIdNameEx`, so I've chosen the easy way which might be not as scalable as desired. :thinking: 