### PR TITLE
Fix passive wait analysis on Windows 7/8

### DIFF
--- a/phnt/include/ntpsapi.h
+++ b/phnt/include/ntpsapi.h
@@ -911,12 +911,9 @@ typedef struct _THREAD_LAST_SYSCALL_INFORMATION
 {
     PVOID FirstArgument;
     USHORT SystemCallNumber;
-#ifdef WIN64
-    USHORT Pad[0x3]; // since REDSTONE2
-#else
-    USHORT Pad[0x1]; // since REDSTONE2
+#if (PHNT_VERSION >= PHNT_WINBLUE)
+    ULONG64 WaitTime; // may be omitted
 #endif
-    ULONG64 WaitTime;
 } THREAD_LAST_SYSCALL_INFORMATION, *PTHREAD_LAST_SYSCALL_INFORMATION;
 
 // private


### PR DESCRIPTION
`NtQueryInformationThread(ThreadLastSystemCall)` currently always fails on Windows 7/8 with `STATUS_INFO_LENGTH_MISMATCH` due to the `WaitTime` member, which was only added in 8.1. This makes passive thread wait analysis fail in PH.

I've moved the `WaitTime` field inside an `#if` version check, but note that the call will still succeed on Windows 8.1 and 10 without this field, since `PspQueryLastCallThread` accepts both versions of the struct.

Re: the `Pad` fields: I've removed these since the sizes and offsets are already correct due to compiler inserted padding for both x86 and x64.