### PR TITLE
Fix some potential null dereferences

### DIFF
--- a/ProcessHacker/hndlprp.c
+++ b/ProcessHacker/hndlprp.c
@@ -1064,9 +1064,9 @@ VOID PhpUpdateHandleGeneral(
 
                 status = PhGetStatusMessage(exitStatus, 0);
                 exitcode = PhFormatString(
-                    L"0x%x (%s)",
+                    status ? L"0x%x (%s)" : L"0x%x",
                     exitStatus,
-                    status->Buffer
+                    PhGetString(status)
                     );
 
                 PhSetListViewSubItem(
@@ -1077,7 +1077,11 @@ VOID PhpUpdateHandleGeneral(
                     );
 
                 PhDereferenceObject(exitcode);
-                PhDereferenceObject(status);
+
+                if (status)
+                {
+                    PhDereferenceObject(status);
+                }
             }
 
             NtClose(dupHandle);
@@ -1164,9 +1168,9 @@ VOID PhpUpdateHandleGeneral(
 
                 status = PhGetStatusMessage(exitStatus, 0);
                 exitcode = PhFormatString(
-                    L"0x%x (%s)",
+                    status ? L"0x%x (%s)" : L"0x%x",
                     exitStatus,
-                    status->Buffer
+                    PhGetString(status)
                     );
 
                 PhSetListViewSubItem(
@@ -1177,7 +1181,11 @@ VOID PhpUpdateHandleGeneral(
                     );
 
                 PhDereferenceObject(exitcode);
-                PhDereferenceObject(status);
+
+                if (status)
+                {
+                    PhDereferenceObject(status);
+                }
             }
 
             NtClose(dupHandle);

--- a/ProcessHacker/main.c
+++ b/ProcessHacker/main.c
@@ -903,7 +903,7 @@ VOID PhpShowKphError(
         {
             statusMessage = PhConcatStrings(
                 3,
-                errorMessage->Buffer,
+                PhGetStringOrDefault(errorMessage, L"Unknown error."),
                 L"\r\n\r\n",
                 L"You will be unable to use more advanced features, view details about system processes or terminate malicious software."
                 );

--- a/plugins/ExtendedServices/depend.c
+++ b/plugins/ExtendedServices/depend.c
@@ -207,7 +207,7 @@ ContinueLoop:
             if (!success)
             {
                 PhSetDialogItemText(hwndDlg, IDC_SERVICES_LAYOUT, PhaConcatStrings2(L"Unable to enumerate dependencies: ",
-                    ((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))->Buffer)->Buffer);
+                    PhGetString((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result))))->Buffer);
                 ShowWindow(GetDlgItem(hwndDlg, IDC_SERVICES_LAYOUT), SW_SHOW);
             }
 
@@ -321,7 +321,7 @@ INT_PTR CALLBACK EspServiceDependentsDlgProc(
             if (!success)
             {
                 PhSetDialogItemText(hwndDlg, IDC_SERVICES_LAYOUT, PhaConcatStrings2(L"Unable to enumerate dependents: ",
-                    ((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))->Buffer)->Buffer);
+                    PhGetString((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result))))->Buffer);
                 ShowWindow(GetDlgItem(hwndDlg, IDC_SERVICES_LAYOUT), SW_SHOW);
             }
 

--- a/plugins/ExtendedServices/other.c
+++ b/plugins/ExtendedServices/other.c
@@ -376,7 +376,7 @@ INT_PTR CALLBACK EspServiceOtherDlgProc(
             if (!NT_SUCCESS(status))
             {
                 PhShowWarning(hwndDlg, L"Unable to query service information: %s",
-                    ((PPH_STRING)PH_AUTO(PhGetNtMessage(status)))->Buffer);
+                    PhGetString((PPH_STRING)PH_AUTO(PhGetNtMessage(status))));
             }
 
             context->Ready = TRUE;
@@ -713,7 +713,7 @@ Done:
                                 hwndDlg,
                                 MB_ICONERROR | MB_RETRYCANCEL,
                                 L"Unable to change service information: %s",
-                                ((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))->Buffer
+                                PhGetString((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))
                                 ) == IDRETRY)
                             {
                                 SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID);

--- a/plugins/ExtendedServices/recovery.c
+++ b/plugins/ExtendedServices/recovery.c
@@ -323,7 +323,7 @@ INT_PTR CALLBACK EspServiceRecoveryDlgProc(
                 EnableWindow(GetDlgItem(hwndDlg, IDC_ENABLEFORERRORSTOPS), TRUE);
  
                 PhShowWarning(hwndDlg, L"Unable to query service recovery information: %s",
-                    ((PPH_STRING)PH_AUTO(PhGetNtMessage(status)))->Buffer);
+                    PhGetString((PPH_STRING)PH_AUTO(PhGetNtMessage(status))));
             }
 
             EspFixControls(hwndDlg, context);
@@ -559,7 +559,7 @@ ErrorCase:
                         hwndDlg,
                         MB_ICONERROR | MB_RETRYCANCEL,
                         L"Unable to change service recovery information: %s",
-                        ((PPH_STRING)PH_AUTO(PhGetWin32Message(GetLastError())))->Buffer
+                        PhGetString((PPH_STRING)PH_AUTO(PhGetWin32Message(GetLastError())))
                         ) == IDRETRY)
                     {
                         SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID);

--- a/plugins/ExtendedServices/triggpg.c
+++ b/plugins/ExtendedServices/triggpg.c
@@ -96,7 +96,7 @@ INT_PTR CALLBACK EspServiceTriggersDlgProc(
             if (!NT_SUCCESS(status))
             {
                 PhShowWarning(hwndDlg, L"Unable to query service trigger information: %s",
-                    ((PPH_STRING)PH_AUTO(PhGetNtMessage(status)))->Buffer);
+                    PhGetString((PPH_STRING)PH_AUTO(PhGetNtMessage(status))));
             }
 
             PhInitializeLayoutManager(&context->LayoutManager, hwndDlg);
@@ -158,7 +158,7 @@ INT_PTR CALLBACK EspServiceTriggersDlgProc(
                             hwndDlg,
                             MB_ICONERROR | MB_RETRYCANCEL,
                             L"Unable to change service trigger information: %s",
-                            ((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))->Buffer
+                            PhGetString((PPH_STRING)PH_AUTO(PhGetWin32Message(win32Result)))
                             ) == IDRETRY))
                         {
                             SetWindowLongPtr(hwndDlg, DWLP_MSGRESULT, PSNRET_INVALID);

--- a/tools/CustomSignTool/main.c
+++ b/tools/CustomSignTool/main.c
@@ -100,7 +100,7 @@ static VOID CstFailWithStatus(
     _In_opt_ ULONG Win32Result
     )
 {
-    wprintf(L"%s: %s\n", Message, PhGetStatusMessage(Status, Win32Result)->Buffer);
+    wprintf(L"%s: %s\n", Message, PhGetStringOrEmpty(PhGetStatusMessage(Status, Win32Result)));
     exit(1);
 }
 


### PR DESCRIPTION
PH used to crash while viewing detailed information about a handle of a terminated process or a thread that exited with a code with no textual description.

Looks like PhGetStatusMessage, PhGetWin32Message, and PhGetNtMessage can return NULL which gets  dereferenced in several places in the code.