### PR TITLE
make RunFileDialog showing 'Run as Administrator' configurable

### DIFF
--- a/ProcessHacker/mainwnd.c
+++ b/ProcessHacker/mainwnd.c
@@ -605,8 +605,13 @@ VOID PhMwpOnCommand(
         break;
     case ID_HACKER_RUN:
         {
+            ULONG flags = RFF_OPTRUNAS;
+            if (PhGetIntegerSetting(L"RunDlgHideRunAsAdministrator"))
+            {
+                flags = 0;
+            }
             SelectedRunAsMode = 0;
-            PhShowRunFileDialog(WindowHandle, NULL, NULL, NULL, NULL, RFF_OPTRUNAS);
+            PhShowRunFileDialog(WindowHandle, NULL, NULL, NULL, NULL, flags);
         }
         break;
     case ID_HACKER_RUNASADMINISTRATOR:

--- a/ProcessHacker/settings.c
+++ b/ProcessHacker/settings.c
@@ -150,6 +150,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"PropagateCpuUsage", L"0");
     PhpAddStringSetting(L"RunAsProgram", L"");
     PhpAddStringSetting(L"RunAsUserName", L"");
+    PhpAddIntegerSetting(L"RunDlgHideRunAsAdministrator", L"0");
     PhpAddIntegerSetting(L"SampleCount", L"200"); // 512
     PhpAddIntegerSetting(L"SampleCountAutomatic", L"1");
     PhpAddIntegerSetting(L"ScrollToNewProcesses", L"0");


### PR DESCRIPTION
Since I have been using the RunFileDialog of ProcessHacker 2.39 a lot in the past years, I've gotten used to the fact that it ran programs as administrator.

Now I tried to update to the latest nightly build of ProcessHacker 3.0 and had to realize that now there is this extra checkbox that has to be clicked in order to run programs as administrator.

That is why I like to propose to introduce a setting that lets me decide whether to have this extra checkbox or not. In this pull request the default to display it. And there is no UI to change that. But I added a setting so that the checkbox can be disable manually.
