### PR TITLE
Detect terminated threads correctly

### DIFF
--- a/ProcessHacker/hndlprp.c
+++ b/ProcessHacker/hndlprp.c
@@ -1100,7 +1100,7 @@ VOID PhpUpdateHandleGeneral(
 
         if (NT_SUCCESS(status))
         {
-            ULONG isTerminated = FALSE;
+            BOOL isTerminated = FALSE;
             THREAD_BASIC_INFORMATION basicInfo;
             KERNEL_USER_TIMES times;
             PPH_STRING name;
@@ -1111,8 +1111,13 @@ VOID PhpUpdateHandleGeneral(
                 PhDereferenceObject(name);
             }
 
-            PhGetThreadIsTerminated(dupHandle, &isTerminated);
-            
+            NtQueryInformationThread(dupHandle,
+                ThreadIsTerminated,
+                &isTerminated,
+                sizeof(BOOL),
+                NULL
+                );
+
             if (isTerminated && NT_SUCCESS(PhGetThreadBasicInformation(dupHandle, &basicInfo)))
             {
                 PPH_STRING status;

--- a/ProcessHacker/hndlprp.c
+++ b/ProcessHacker/hndlprp.c
@@ -1100,7 +1100,7 @@ VOID PhpUpdateHandleGeneral(
 
         if (NT_SUCCESS(status))
         {
-            BOOL isTerminated = FALSE;
+            BOOLEAN isTerminated = FALSE;
             THREAD_BASIC_INFORMATION basicInfo;
             KERNEL_USER_TIMES times;
             PPH_STRING name;
@@ -1111,12 +1111,7 @@ VOID PhpUpdateHandleGeneral(
                 PhDereferenceObject(name);
             }
 
-            NtQueryInformationThread(dupHandle,
-                ThreadIsTerminated,
-                &isTerminated,
-                sizeof(BOOL),
-                NULL
-                );
+            PhGetThreadIsTerminated(dupHandle, &isTerminated);
 
             if (isTerminated && NT_SUCCESS(PhGetThreadBasicInformation(dupHandle, &basicInfo)))
             {

--- a/ProcessHacker/hndlprp.c
+++ b/ProcessHacker/hndlprp.c
@@ -1100,7 +1100,7 @@ VOID PhpUpdateHandleGeneral(
 
         if (NT_SUCCESS(status))
         {
-            BOOL isTerminated = FALSE;
+            ULONG isTerminated = FALSE;
             THREAD_BASIC_INFORMATION basicInfo;
             KERNEL_USER_TIMES times;
             PPH_STRING name;
@@ -1111,13 +1111,8 @@ VOID PhpUpdateHandleGeneral(
                 PhDereferenceObject(name);
             }
 
-            NtQueryInformationThread(dupHandle,
-                ThreadIsTerminated,
-                &isTerminated,
-                sizeof(BOOL),
-                NULL
-                );
-
+            PhGetThreadIsTerminated(dupHandle, &isTerminated);
+            
             if (isTerminated && NT_SUCCESS(PhGetThreadBasicInformation(dupHandle, &basicInfo)))
             {
                 PPH_STRING status;

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -650,6 +650,29 @@ PhGetThreadBasicInformation(
         );
 }
 
+/**
+ * Determines whether a thread is terminated.
+ *
+ * \param ThreadHandle A handle to a thread. The handle must have THREAD_QUERY_LIMITED_INFORMATION
+ * access.
+ * \param IsTerminated A variable which receives 0 if the thread is alive or a non-zero value otherwise.
+ */
+FORCEINLINE
+NTSTATUS
+PhGetThreadIsTerminated(
+    _In_ HANDLE ThreadHandle,
+    _Out_ PULONG IsTerminated
+    )
+{
+    return NtQueryInformationThread(
+        ThreadHandle,
+        ThreadIsTerminated,
+        IsTerminated,
+        sizeof(ULONG),
+        NULL
+        );
+}
+
 FORCEINLINE
 NTSTATUS
 PhGetThreadBasePriority(

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -650,29 +650,6 @@ PhGetThreadBasicInformation(
         );
 }
 
-/**
- * Determines whether a thread is terminated.
- *
- * \param ThreadHandle A handle to a thread. The handle must have THREAD_QUERY_LIMITED_INFORMATION
- * access.
- * \param IsTerminated A variable which receives 0 if the thread is alive or a non-zero value otherwise.
- */
-FORCEINLINE
-NTSTATUS
-PhGetThreadIsTerminated(
-    _In_ HANDLE ThreadHandle,
-    _Out_ PULONG IsTerminated
-    )
-{
-    return NtQueryInformationThread(
-        ThreadHandle,
-        ThreadIsTerminated,
-        IsTerminated,
-        sizeof(ULONG),
-        NULL
-        );
-}
-
 FORCEINLINE
 NTSTATUS
 PhGetThreadBasePriority(


### PR DESCRIPTION
If a thread exits with STATUS_PENDING, Process Hacker assumes it's still alive, while it is not. Fix this behavior by using the `ThreadIsTerminated` information class.