### PR TITLE
fix hash object handling in sign tool

### DIFF
--- a/tools/CustomSignTool/main.c
+++ b/tools/CustomSignTool/main.c
@@ -213,8 +213,8 @@ static PVOID CstHashFile(
     hash = PhAllocate(hashSize);
     if (!NT_SUCCESS(status = BCryptFinishHash(hashHandle, hash, hashSize, 0)))
         CstFailWithStatus(L"Unable to complete the hash", status, 0);
-    PhFree(hashObject);
     BCryptDestroyHash(hashHandle);
+    PhFree(hashObject); // must be freed after destroying hash object
     BCryptCloseAlgorithmProvider(hashAlgHandle, 0);
 
     *HashSize = hashSize;


### PR DESCRIPTION
You have to destroy a hash object before it is legal to free its storage. The [documentation](https://docs.microsoft.com/en-us/windows/win32/api/bcrypt/nf-bcrypt-bcryptcreatehash) is clear about this sequence:
`This memory can only be freed after the handle pointed to by the phHash parameter is destroyed.`
With the original code as a prototype, I have experienced crashes before - not with the corrected one.
