### PR TITLE
Make several functions from ntrtl.h take const strings

### DIFF
--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -1248,7 +1248,7 @@ RtlWakeAddressSingle(
 #ifndef PHNT_NO_INLINE_INIT_STRING
 FORCEINLINE VOID RtlInitString(
     _Out_ PSTRING DestinationString,
-    _In_opt_ PSTR SourceString
+    _In_opt_ PCSTR SourceString
     )
 {
     if (SourceString)
@@ -1256,7 +1256,7 @@ FORCEINLINE VOID RtlInitString(
     else
         DestinationString->MaximumLength = DestinationString->Length = 0;
 
-    DestinationString->Buffer = SourceString;
+    DestinationString->Buffer = (PCHAR)SourceString;
 }
 #else
 NTSYSAPI
@@ -1264,7 +1264,7 @@ VOID
 NTAPI
 RtlInitString(
     _Out_ PSTRING DestinationString,
-    _In_opt_ PSTR SourceString
+    _In_opt_ PCSTR SourceString
     );
 #endif
 
@@ -1281,7 +1281,7 @@ RtlInitStringEx(
 #ifndef PHNT_NO_INLINE_INIT_STRING
 FORCEINLINE VOID RtlInitAnsiString(
     _Out_ PANSI_STRING DestinationString,
-    _In_opt_ PSTR SourceString
+    _In_opt_ PCSTR SourceString
     )
 {
     if (SourceString)
@@ -1289,7 +1289,7 @@ FORCEINLINE VOID RtlInitAnsiString(
     else
         DestinationString->MaximumLength = DestinationString->Length = 0;
 
-    DestinationString->Buffer = SourceString;
+    DestinationString->Buffer = (PCHAR)SourceString;
 }
 #else
 NTSYSAPI
@@ -1297,7 +1297,7 @@ VOID
 NTAPI
 RtlInitAnsiString(
     _Out_ PANSI_STRING DestinationString,
-    _In_opt_ PSTR SourceString
+    _In_opt_ PCSTR SourceString
     );
 #endif
 
@@ -1383,7 +1383,7 @@ NTSTATUS
 NTAPI
 RtlAppendAsciizToString(
     _In_ PSTRING Destination,
-    _In_opt_ PSTR Source
+    _In_opt_ PCSTR Source
     );
 
 NTSYSAPI
@@ -1420,7 +1420,7 @@ RtlInitEmptyUnicodeString(
 #ifndef PHNT_NO_INLINE_INIT_STRING
 FORCEINLINE VOID RtlInitUnicodeString(
     _Out_ PUNICODE_STRING DestinationString,
-    _In_opt_ PWSTR SourceString
+    _In_opt_ PCWSTR SourceString
     )
 {
     if (SourceString)
@@ -1428,7 +1428,7 @@ FORCEINLINE VOID RtlInitUnicodeString(
     else
         DestinationString->MaximumLength = DestinationString->Length = 0;
 
-    DestinationString->Buffer = SourceString;
+    DestinationString->Buffer = (PWCH)SourceString;
 }
 #else
 NTSYSAPI
@@ -1436,7 +1436,7 @@ VOID
 NTAPI
 RtlInitUnicodeString(
     _Out_ PUNICODE_STRING DestinationString,
-    _In_opt_ PWSTR SourceString
+    _In_opt_ PCWSTR SourceString
     );
 #endif
 
@@ -1445,7 +1445,7 @@ NTSTATUS
 NTAPI
 RtlInitUnicodeStringEx(
     _Out_ PUNICODE_STRING DestinationString,
-    _In_opt_ PWSTR SourceString
+    _In_opt_ PCWSTR SourceString
     );
 
 NTSYSAPI
@@ -1453,7 +1453,7 @@ BOOLEAN
 NTAPI
 RtlCreateUnicodeString(
     _Out_ PUNICODE_STRING DestinationString,
-    _In_ PWSTR SourceString
+    _In_ PCWSTR SourceString
     );
 
 NTSYSAPI
@@ -1461,7 +1461,7 @@ BOOLEAN
 NTAPI
 RtlCreateUnicodeStringFromAsciiz(
     _Out_ PUNICODE_STRING DestinationString,
-    _In_ PSTR SourceString
+    _In_ PCSTR SourceString
     );
 
 NTSYSAPI
@@ -1521,9 +1521,9 @@ NTSYSAPI
 LONG
 NTAPI
 RtlCompareUnicodeStrings(
-    _In_reads_(String1Length) PWCH String1,
+    _In_reads_(String1Length) PCWCH String1,
     _In_ SIZE_T String1Length,
-    _In_reads_(String2Length) PWCH String2,
+    _In_reads_(String2Length) PCWCH String2,
     _In_ SIZE_T String2Length,
     _In_ BOOLEAN CaseInSensitive
     );
@@ -1622,7 +1622,7 @@ NTSTATUS
 NTAPI
 RtlAppendUnicodeToString(
     _In_ PUNICODE_STRING Destination,
-    _In_opt_ PWSTR Source
+    _In_opt_ PCWSTR Source
     );
 
 NTSYSAPI
@@ -1736,7 +1736,7 @@ RtlMultiByteToUnicodeN(
     _Out_writes_bytes_to_(MaxBytesInUnicodeString, *BytesInUnicodeString) PWCH UnicodeString,
     _In_ ULONG MaxBytesInUnicodeString,
     _Out_opt_ PULONG BytesInUnicodeString,
-    _In_reads_bytes_(BytesInMultiByteString) PSTR MultiByteString,
+    _In_reads_bytes_(BytesInMultiByteString) PCSTR MultiByteString,
     _In_ ULONG BytesInMultiByteString
     );
 
@@ -1745,7 +1745,7 @@ NTSTATUS
 NTAPI
 RtlMultiByteToUnicodeSize(
     _Out_ PULONG BytesInUnicodeString,
-    _In_reads_bytes_(BytesInMultiByteString) PSTR MultiByteString,
+    _In_reads_bytes_(BytesInMultiByteString) PCSTR MultiByteString,
     _In_ ULONG BytesInMultiByteString
     );
 
@@ -1756,7 +1756,7 @@ RtlUnicodeToMultiByteN(
     _Out_writes_bytes_to_(MaxBytesInMultiByteString, *BytesInMultiByteString) PCHAR MultiByteString,
     _In_ ULONG MaxBytesInMultiByteString,
     _Out_opt_ PULONG BytesInMultiByteString,
-    _In_reads_bytes_(BytesInUnicodeString) PWCH UnicodeString,
+    _In_reads_bytes_(BytesInUnicodeString) PCWCH UnicodeString,
     _In_ ULONG BytesInUnicodeString
     );
 
@@ -1765,7 +1765,7 @@ NTSTATUS
 NTAPI
 RtlUnicodeToMultiByteSize(
     _Out_ PULONG BytesInMultiByteString,
-    _In_reads_bytes_(BytesInUnicodeString) PWCH UnicodeString,
+    _In_reads_bytes_(BytesInUnicodeString) PCWCH UnicodeString,
     _In_ ULONG BytesInUnicodeString
     );
 
@@ -1776,7 +1776,7 @@ RtlUpcaseUnicodeToMultiByteN(
     _Out_writes_bytes_to_(MaxBytesInMultiByteString, *BytesInMultiByteString) PCHAR MultiByteString,
     _In_ ULONG MaxBytesInMultiByteString,
     _Out_opt_ PULONG BytesInMultiByteString,
-    _In_reads_bytes_(BytesInUnicodeString) PWCH UnicodeString,
+    _In_reads_bytes_(BytesInUnicodeString) PCWCH UnicodeString,
     _In_ ULONG BytesInUnicodeString
     );
 
@@ -1787,7 +1787,7 @@ RtlOemToUnicodeN(
     _Out_writes_bytes_to_(MaxBytesInUnicodeString, *BytesInUnicodeString) PWSTR UnicodeString,
     _In_ ULONG MaxBytesInUnicodeString,
     _Out_opt_ PULONG BytesInUnicodeString,
-    _In_reads_bytes_(BytesInOemString) PCH OemString,
+    _In_reads_bytes_(BytesInOemString) PCCH OemString,
     _In_ ULONG BytesInOemString
     );
 
@@ -1798,7 +1798,7 @@ RtlUnicodeToOemN(
     _Out_writes_bytes_to_(MaxBytesInOemString, *BytesInOemString) PCHAR OemString,
     _In_ ULONG MaxBytesInOemString,
     _Out_opt_ PULONG BytesInOemString,
-    _In_reads_bytes_(BytesInUnicodeString) PWCH UnicodeString,
+    _In_reads_bytes_(BytesInUnicodeString) PCWCH UnicodeString,
     _In_ ULONG BytesInUnicodeString
     );
 
@@ -1809,7 +1809,7 @@ RtlUpcaseUnicodeToOemN(
     _Out_writes_bytes_to_(MaxBytesInOemString, *BytesInOemString) PCHAR OemString,
     _In_ ULONG MaxBytesInOemString,
     _Out_opt_ PULONG BytesInOemString,
-    _In_reads_bytes_(BytesInUnicodeString) PWCH UnicodeString,
+    _In_reads_bytes_(BytesInUnicodeString) PCWCH UnicodeString,
     _In_ ULONG BytesInUnicodeString
     );
 
@@ -1820,7 +1820,7 @@ RtlConsoleMultiByteToUnicodeN(
     _Out_writes_bytes_to_(MaxBytesInUnicodeString, *BytesInUnicodeString) PWCH UnicodeString,
     _In_ ULONG MaxBytesInUnicodeString,
     _Out_opt_ PULONG BytesInUnicodeString,
-    _In_reads_bytes_(BytesInMultiByteString) PCH MultiByteString,
+    _In_reads_bytes_(BytesInMultiByteString) PCCH MultiByteString,
     _In_ ULONG BytesInMultiByteString,
     _Out_ PULONG pdwSpecialChar
     );
@@ -1833,7 +1833,7 @@ RtlUTF8ToUnicodeN(
     _Out_writes_bytes_to_(UnicodeStringMaxByteCount, *UnicodeStringActualByteCount) PWSTR UnicodeStringDestination,
     _In_ ULONG UnicodeStringMaxByteCount,
     _Out_ PULONG UnicodeStringActualByteCount,
-    _In_reads_bytes_(UTF8StringByteCount) PCH UTF8StringSource,
+    _In_reads_bytes_(UTF8StringByteCount) PCCH UTF8StringSource,
     _In_ ULONG UTF8StringByteCount
     );
 #endif
@@ -1846,7 +1846,7 @@ RtlUnicodeToUTF8N(
     _Out_writes_bytes_to_(UTF8StringMaxByteCount, *UTF8StringActualByteCount) PCHAR UTF8StringDestination,
     _In_ ULONG UTF8StringMaxByteCount,
     _Out_ PULONG UTF8StringActualByteCount,
-    _In_reads_bytes_(UnicodeStringByteCount) PWCH UnicodeStringSource,
+    _In_reads_bytes_(UnicodeStringByteCount) PCWCH UnicodeStringSource,
     _In_ ULONG UnicodeStringByteCount
     );
 #endif
@@ -2058,7 +2058,7 @@ NTSTATUS
 NTAPI
 RtlIdnToAscii(
     _In_ ULONG Flags,
-    _In_ PWSTR SourceString,
+    _In_ PCWSTR SourceString,
     _In_ LONG SourceStringLength,
     _Out_writes_to_(*DestinationStringLength, *DestinationStringLength) PWSTR DestinationString,
     _Inout_ PLONG DestinationStringLength
@@ -2069,7 +2069,7 @@ NTSTATUS
 NTAPI
 RtlIdnToUnicode(
     _In_ ULONG Flags,
-    _In_ PWSTR SourceString,
+    _In_ PCWSTR SourceString,
     _In_ LONG SourceStringLength,
     _Out_writes_to_(*DestinationStringLength, *DestinationStringLength) PWSTR DestinationString,
     _Inout_ PLONG DestinationStringLength
@@ -2080,7 +2080,7 @@ NTSTATUS
 NTAPI
 RtlIdnToNameprepUnicode(
     _In_ ULONG Flags,
-    _In_ PWSTR SourceString,
+    _In_ PCWSTR SourceString,
     _In_ LONG SourceStringLength,
     _Out_writes_to_(*DestinationStringLength, *DestinationStringLength) PWSTR DestinationString,
     _Inout_ PLONG DestinationStringLength
@@ -2346,7 +2346,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 RtlIsValidLocaleName(
-    _In_ PWSTR LocaleName,
+    _In_ PCWSTR LocaleName,
     _In_ ULONG Flags
     );
 
@@ -2355,7 +2355,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlGetParentLocaleName(
-    _In_ PWSTR LocaleName,
+    _In_ PCWSTR LocaleName,
     _Inout_ PUNICODE_STRING ParentLocaleName,
     _In_ ULONG Flags,
     _In_ BOOLEAN AllocateDestinationString
@@ -2377,7 +2377,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlLocaleNameToLcid(
-    _In_ PWSTR LocaleName,
+    _In_ PCWSTR LocaleName,
     _Out_ PLCID lcid,
     _In_ ULONG Flags
     );
@@ -3182,7 +3182,7 @@ PVOID
 NTAPI
 RtlFindExportedRoutineByName(
     _In_ PVOID BaseOfImage,
-    _In_ PSTR RoutineName
+    _In_ PCSTR RoutineName
     );
 
 #endif
@@ -3280,9 +3280,9 @@ NTSTATUS
 NTAPI
 RtlSetEnvironmentVar(
     _Inout_opt_ PVOID *Environment,
-    _In_reads_(NameLength) PWSTR Name,
+    _In_reads_(NameLength) PCWSTR Name,
     _In_ SIZE_T NameLength,
-    _In_reads_(ValueLength) PWSTR Value,
+    _In_reads_(ValueLength) PCWSTR Value,
     _In_ SIZE_T ValueLength
     );
 #endif
@@ -3303,7 +3303,7 @@ NTSTATUS
 NTAPI
 RtlQueryEnvironmentVariable(
     _In_opt_ PVOID Environment,
-    _In_reads_(NameLength) PWSTR Name,
+    _In_reads_(NameLength) PCWSTR Name,
     _In_ SIZE_T NameLength,
     _Out_writes_(ValueLength) PWSTR Value,
     _In_ SIZE_T ValueLength,
@@ -3327,7 +3327,7 @@ NTSTATUS
 NTAPI
 RtlExpandEnvironmentStrings(
     _In_opt_ PVOID Environment,
-    _In_reads_(SrcLength) PWSTR Src,
+    _In_reads_(SrcLength) PCWSTR Src,
     _In_ SIZE_T SrcLength,
     _Out_writes_(DstLength) PWSTR Dst,
     _In_ SIZE_T DstLength,
@@ -3349,7 +3349,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlSetEnvironmentStrings(
-    _In_ PWCHAR NewEnvironment,
+    _In_ PCWCHAR NewEnvironment,
     _In_ SIZE_T NewEnvironmentSize
     );
 
@@ -3400,7 +3400,7 @@ NTSYSAPI
 RTL_PATH_TYPE
 NTAPI
 RtlDetermineDosPathNameType_U(
-    _In_ PWSTR DosFileName
+    _In_ PCWSTR DosFileName
     );
 
 NTSYSAPI
@@ -3414,7 +3414,7 @@ NTSYSAPI
 ULONG
 NTAPI
 RtlIsDosDeviceName_U(
-    _In_ PWSTR DosFileName
+    _In_ PCWSTR DosFileName
     );
 
 NTSYSAPI
@@ -3428,7 +3428,7 @@ NTSYSAPI
 ULONG
 NTAPI
 RtlGetFullPathName_U(
-    _In_ PWSTR FileName,
+    _In_ PCWSTR FileName,
     _In_ ULONG BufferLength,
     _Out_writes_bytes_(BufferLength) PWSTR Buffer,
     _Out_opt_ PWSTR *FilePart
@@ -3440,7 +3440,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlGetFullPathName_UEx(
-    _In_ PWSTR FileName,
+    _In_ PCWSTR FileName,
     _In_ ULONG BufferLength,
     _Out_writes_bytes_(BufferLength) PWSTR Buffer,
     _Out_opt_ PWSTR *FilePart,
@@ -3490,7 +3490,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 RtlDosPathNameToNtPathName_U(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3501,7 +3501,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlDosPathNameToNtPathName_U_WithStatus(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3514,7 +3514,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlDosLongPathNameToNtPathName_U_WithStatus(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3526,7 +3526,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 RtlDosPathNameToRelativeNtPathName_U(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3538,7 +3538,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlDosPathNameToRelativeNtPathName_U_WithStatus(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3551,7 +3551,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlDosLongPathNameToRelativeNtPathName_U_WithStatus(
-    _In_ PWSTR DosFileName,
+    _In_ PCWSTR DosFileName,
     _Out_ PUNICODE_STRING NtFileName,
     _Out_opt_ PWSTR *FilePart,
     _Out_opt_ PRTL_RELATIVE_NAME_U RelativeName
@@ -3571,9 +3571,9 @@ NTSYSAPI
 ULONG
 NTAPI
 RtlDosSearchPath_U(
-    _In_ PWSTR Path,
-    _In_ PWSTR FileName,
-    _In_opt_ PWSTR Extension,
+    _In_ PCWSTR Path,
+    _In_ PCWSTR FileName,
+    _In_opt_ PCWSTR Extension,
     _In_ ULONG BufferLength,
     _Out_writes_bytes_(BufferLength) PWSTR Buffer,
     _Out_opt_ PWSTR *FilePart
@@ -3602,7 +3602,7 @@ NTSYSAPI
 BOOLEAN
 NTAPI
 RtlDoesFileExists_U(
-    _In_ PWSTR FileName
+    _In_ PCWSTR FileName
     );
 
 NTSYSAPI
@@ -4843,7 +4843,7 @@ NTSYSAPI
 NTSTATUS
 NTAPI
 RtlCharToInteger(
-    _In_ PSTR String,
+    _In_ PCSTR String,
     _In_opt_ ULONG Base,
     _Out_ PULONG Value
     );
@@ -6938,7 +6938,7 @@ NTSTATUS
 NTAPI
 RtlQueryRegistryValues(
     _In_ ULONG RelativeTo,
-    _In_ PWSTR Path,
+    _In_ PCWSTR Path,
     _In_ PRTL_QUERY_REGISTRY_TABLE QueryTable,
     _In_ PVOID Context,
     _In_opt_ PVOID Environment
@@ -6950,7 +6950,7 @@ NTSTATUS
 NTAPI
 RtlQueryRegistryValuesEx(
     _In_ ULONG RelativeTo,
-    _In_ PWSTR Path,
+    _In_ PCWSTR Path,
     _In_ PRTL_QUERY_REGISTRY_TABLE QueryTable,
     _In_ PVOID Context,
     _In_opt_ PVOID Environment
@@ -6961,8 +6961,8 @@ NTSTATUS
 NTAPI
 RtlWriteRegistryValue(
     _In_ ULONG RelativeTo,
-    _In_ PWSTR Path,
-    _In_ PWSTR ValueName,
+    _In_ PCWSTR Path,
+    _In_ PCWSTR ValueName,
     _In_ ULONG ValueType,
     _In_ PVOID ValueData,
     _In_ ULONG ValueLength
@@ -6973,8 +6973,8 @@ NTSTATUS
 NTAPI
 RtlDeleteRegistryValue(
     _In_ ULONG RelativeTo,
-    _In_ PWSTR Path,
-    _In_ PWSTR ValueName
+    _In_ PCWSTR Path,
+    _In_ PCWSTR ValueName
     );
 
 // Thread profiling


### PR DESCRIPTION
I went through all the functions in `ntrtl.h` that took non-`const` string parameters (like `PCHAR`) that were marked as `_In_` and checked the documentation on MSDN (or reactOS if undocumented) to see if the parameters were `const` or not, and updated the definitions accordingly. I didn't touch any functions that I couldn't find sufficient documentation on.

phlib and ProcessHacker compile cleanly with no warnings caused from these changes.