### PR TITLE
Align & improve updater wordings 

### DIFF
--- a/plugins/Updater/page1.c
+++ b/plugins/Updater/page1.c
@@ -24,7 +24,7 @@
 
 static TASKDIALOG_BUTTON TaskDialogButtonArray[] =
 {
-    { IDOK, L"Check for updates" }
+    { IDOK, L"Check" }
 };
 
 HRESULT CALLBACK CheckForUpdatesCallbackProc(
@@ -74,9 +74,9 @@ VOID ShowCheckForUpdatesDialog(
     config.lpCallbackData = (LONG_PTR)Context;
 
     config.pszWindowTitle = L"Process Hacker - Updater";
-    config.pszMainInstruction = L"Check for new Process Hacker releases?";
-    //config.pszContent = L"The updater will check for new Process Hacker releases and optionally download and install the update.\r\n\r\nClick the check for updates button to continue.";
-    config.pszContent = L"Select \"check for updates\" to continue.\r\n";
+    config.pszMainInstruction = L"Check for an updated Process Hacker release?";
+    //config.pszContent = L"The updater will check for an updated Process Hacker release which then can be optionally downloaded and installed.\r\n\r\nClick Check to continue.";
+    config.pszContent = L"Click Check to continue.\r\n";
 
     TaskDialogNavigatePage(Context->DialogHandle, &config);
 }

--- a/plugins/Updater/page2.c
+++ b/plugins/Updater/page2.c
@@ -64,7 +64,7 @@ VOID ShowCheckingForUpdatesDialog(
     config.lpCallbackData = (LONG_PTR)Context;
 
     config.pszWindowTitle = L"Process Hacker - Updater";
-    config.pszMainInstruction = L"Checking for new releases...";
+    config.pszMainInstruction = L"Checking for an updated release...";
 
     TaskDialogNavigatePage(Context->DialogHandle, &config);
 }

--- a/plugins/Updater/updater.c
+++ b/plugins/Updater/updater.c
@@ -697,7 +697,7 @@ NTSTATUS UpdateDownloadThread(
         IO_STATUS_BLOCK isb;
         BYTE buffer[PAGE_SIZE];
 
-        status = PhFormatString(L"Downloading update %s...", PhGetStringOrEmpty(context->Version));
+        status = PhFormatString(L"Downloading release %s...", PhGetStringOrEmpty(context->Version));
 
         SendMessage(context->DialogHandle, TDM_SET_MARQUEE_PROGRESS_BAR, FALSE, 0);
         SendMessage(context->DialogHandle, TDM_UPDATE_ELEMENT_TEXT, TDE_MAIN_INSTRUCTION, (LPARAM)status->Buffer);
@@ -772,15 +772,15 @@ NTSTATUS UpdateDownloadThread(
                 PH_FORMAT format[9];
                 WCHAR string[MAX_PATH];
 
-                // L"Downloaded: %s of %s (%.0f%%)\r\nSpeed: %s/s"
+                // L"Downloaded: %s / %s (%.0f%%)\r\nSpeed: %s/s"
                 PhInitFormatS(&format[0], L"Downloaded: ");
-                PhInitFormatSize(&format[1], downloadedBytes);
-                PhInitFormatS(&format[2], L" of ");
-                PhInitFormatSize(&format[3], contentLength);
+                PhInitFormatSize(&format[1], downloadedBytes / 1024);
+                PhInitFormatS(&format[2], L" / ");
+                PhInitFormatSize(&format[3], contentLength / 1024);
                 PhInitFormatS(&format[4], L" (");
                 PhInitFormatF(&format[5], percent, 1);
                 PhInitFormatS(&format[6], L"%)\r\nSpeed: ");
-                PhInitFormatSize(&format[7], timeBitsPerSecond);
+                PhInitFormatSize(&format[7], timeBitsPerSecond / 1024);
                 PhInitFormatS(&format[8], L"/s");
 
                 if (PhFormatToBuffer(format, RTL_NUMBER_OF(format), string, sizeof(string), NULL))


### PR DESCRIPTION
Aligns the check button's caption with common best practices (1 word on button) & improves the instruction's texts while check is running & the reported sizes/speed in more modern units.

Please review & suggest edits where needed.