### PR TITLE
Initialize ImageCoherencyStatus

### DIFF
--- a/ProcessHacker/procprv.c
+++ b/ProcessHacker/procprv.c
@@ -435,6 +435,14 @@ PPH_PROCESS_ITEM PhCreateProcessItem(
 
     PhEmCallObjectOperation(EmProcessItemType, processItem, EmObjectCreate);
 
+    //
+    // Initialize ImageCoherencyStatus to STATUS_PENDING this notes that the
+    // image coherency hasn't been done yet. This prevents the process items
+    // from being noted as "Low Image Coherency" or being highlighted until
+    // the analysis runs. See: PhpShouldShowImageCoherency
+    //
+    processItem->ImageCoherencyStatus = STATUS_PENDING;
+
     return processItem;
 }
 

--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -3834,6 +3834,16 @@ BOOLEAN PhpShouldShowImageCoherency(
     )
 {
     //
+    // If we haven't done the image coherency check yet, don't show. We
+    // initialize the process item with STATUS_PENDING to denote this.
+    // See: PhCreateProcessItem
+    //
+    if (ProcessItem->ImageCoherencyStatus == STATUS_PENDING)
+    {
+        return FALSE;
+    }
+
+    //
     // Exclude the fake processes and system idle PID
     //
     if (PH_IS_FAKE_PROCESS_ID(ProcessItem->ProcessId) ||


### PR DESCRIPTION
This PR initializes `ImageCoherencyStatus` in the process item to `STATUS_PENDING`. This will denote that the image coherency check hasn't been run yet on the process item. This is checked in `PhpShouldShowImageCoherency` which prevents the entry in the process table from showing as "Low Image Coherency" or being highlighted until the analysis runs in stage 2.