### PR TITLE
Improve image coherency calucation and configuration

### DIFF
--- a/ProcessHacker/include/phsettings.h
+++ b/ProcessHacker/include/phsettings.h
@@ -81,6 +81,8 @@ EXT ULONG PhCsColorServiceDisabled;
 EXT ULONG PhCsUseColorServiceStop;
 EXT ULONG PhCsColorServiceStop;
 
+EXT ULONG PhCsImageCoherencyScanLevel;
+
 #define PH_SET_INTEGER_CACHED_SETTING(Name, Value) (PhSetIntegerSetting(TEXT(#Name), PhCs##Name = (Value)))
 
 #endif

--- a/ProcessHacker/include/proctree.h
+++ b/ProcessHacker/include/proctree.h
@@ -234,6 +234,7 @@ typedef struct _PH_PROCESS_NODE
     WCHAR PidHexText[PH_PTR_STR_LEN_1];
     WCHAR CpuCoreUsageText[PH_PTR_STR_LEN_1 + 3];
     WCHAR ImageCoherencyText[PH_PTR_STR_LEN_1 + 3];
+    PPH_STRING ImageCoherencyStatusText;
 
     // Graph buffers
     PH_GRAPH_BUFFERS CpuGraphBuffers;

--- a/ProcessHacker/modprv.c
+++ b/ProcessHacker/modprv.c
@@ -412,6 +412,7 @@ NTSTATUS PhpModuleQueryWorker(
                     data->ModuleProvider->ProcessHandle,
                     data->ModuleItem->BaseAddress,
                     data->ModuleItem->Type == PH_MODULE_TYPE_KERNEL_MODULE,
+                    PhImageCoherencyQuick,
                     &data->ImageCoherency
                     );
             }

--- a/ProcessHacker/settings.c
+++ b/ProcessHacker/settings.c
@@ -4,6 +4,7 @@
  *
  * Copyright (C) 2010-2016 wj32
  * Copyright (C) 2017-2020 dmex
+ * Copyright (C) 2021 jxy-s
  *
  * This file is part of Process Hacker.
  *
@@ -96,6 +97,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"IconProcesses", L"f"); // 15
     PhpAddIntegerSetting(L"IconSingleClick", L"0");
     PhpAddIntegerSetting(L"IconTogglesVisibility", L"1");
+    PhpAddIntegerSetting(L"ImageCoherencyScanLevel", L"1");
     PhpAddStringSetting(L"JobListViewColumns", L"");
     //PhpAddIntegerSetting(L"KphUnloadOnShutdown", L"0");
     PhpAddIntegerSetting(L"LogEntries", L"200"); // 512
@@ -334,6 +336,8 @@ VOID PhUpdateCachedSettings(
     PH_UPDATE_SETTING(ColorIoWrite);
     PH_UPDATE_SETTING(ColorPrivate);
     PH_UPDATE_SETTING(ColorPhysical);
+
+    PH_UPDATE_SETTING(ImageCoherencyScanLevel);
 
     PhEnableNetworkResolveDoHSupport = !!PhGetIntegerSetting(L"EnableNetworkResolveDoH");
     PhEnableVersionShortText = !!PhGetIntegerSetting(L"EnableVersionSupport");

--- a/phlib/include/mapimg.h
+++ b/phlib/include/mapimg.h
@@ -809,6 +809,10 @@ NTSTATUS PhGetMappedImageRelocations(
     _Out_ PPH_MAPPED_IMAGE_RELOC Relocations
     );
 
+VOID PhFreeMappedImageRelocations(
+    _In_ PPH_MAPPED_IMAGE_RELOC Relocations
+    );
+
 // ELF binary support
 
 NTSTATUS PhInitializeMappedWslImage(

--- a/phlib/include/phutil.h
+++ b/phlib/include/phutil.h
@@ -1042,12 +1042,46 @@ PhIsExecutablePacked(
     _Out_opt_ PULONG NumberOfFunctions
     );
 
+/**
+* Image Coherency Scan Type
+*/
+typedef enum _PH_IMGCOHERENCY_SCAN_TYPE
+{
+    /**
+    * Quick scan of the image coherency
+    * - Image header information
+    * - A few pages of each executable section
+    * - Scans a few pages at entry point if it exists and was missed due to previous note
+    * - .NET manifests if appropriate
+    */
+    PhImageCoherencyQuick,
+
+    /**
+    * Normal scan of the image coherency
+    * - Image header information
+    * - Up to 40Mib of each executable section 
+    * - Scans a few pages at entry point if it exists and was missed due to previous note
+    * - .NET manifests if appropriate
+    */
+    PhImageCoherencyNormal,
+
+    /**
+    * Full scan of the image coherency
+    * - Image header information
+    * - Complete scan of all executable sections, this will include the entry point
+    * - .NET manifests if appropriate
+    */
+    PhImageCoherencyFull
+
+} PH_IMAGE_COHERENCY_SCAN_TYPE;
+
 PHLIBAPI
 NTSTATUS
 NTAPI
 PhGetProcessImageCoherency(
     _In_ PWSTR FileName,
     _In_ HANDLE ProcessId,
+    _In_ PH_IMAGE_COHERENCY_SCAN_TYPE Type,
     _Out_ PFLOAT ImageCoherency
     );
 
@@ -1059,6 +1093,7 @@ PhGetProcessModuleImageCoherency(
     _In_ HANDLE ProcessHandle,
     _In_ PVOID ImageBaseAddress,
     _In_ BOOLEAN IsKernelModule,
+    _In_ PH_IMAGE_COHERENCY_SCAN_TYPE Type,
     _Out_ PFLOAT ImageCoherency
     );
 


### PR DESCRIPTION
# Summary
This PR improves the image coherency checks by accounting for relocations. This results in much more accurate image coherency calculations.

In addition, we adjust the way we scan slightly. For native images, we will now scan each executable section in the image along with forcing the entry point scan (if missed due to scan limitations). Previously we opted for a quick scan of just the base of the .text section and the entry point.

Ultimately this results in 100% coherency most of the time: 
![image](https://user-images.githubusercontent.com/11687482/105618394-e6503280-5da3-11eb-857d-3a3678459ae5.png)

This PR also introduces a scanning type/level for the image coherency:

```cpp
/**
* Image Coherency Scan Type
*/
typedef enum _PH_IMGCOHERENCY_SCAN_TYPE
{
    /**
    * Quick scan of the image coherency
    * - Image header information
    * - A few pages of each executable section
    * - Scans a few pages at entry point if it exists and was missed due to previous note
    * - .NET manifests if appropriate
    */
    PhImageCoherencyQuick,

    /**
    * Normal scan of the image coherency
    * - Image header information
    * - Up to 40Mib of each executable section 
    * - Scans a few pages at entry point if it exists and was missed due to previous note
    * - .NET manifests if appropriate
    */
    PhImageCoherencyNormal,

    /**
    * Full scan of the image coherency
    * - Image header information
    * - Complete scan of all executable sections, this will include the entry point
    * - .NET manifests if appropriate
    */
    PhImageCoherencyFull

} PH_IMAGE_COHERENCY_SCAN_TYPE;
```

This scanning level is configurable in the `advanced options`:
![image](https://user-images.githubusercontent.com/11687482/105618321-0a5f4400-5da3-11eb-9b69-3a68b3d5afea.png)

The mapping are described in this table:
| ImageCoherencyScanLevel | PH_IMAGE_COHERENCY_SCAN_TYPE | Note |
| --- | --- | --- |
| 0 | N/A | Disable image coherency scan completely |
| 1 | PhImageCoherencyQuick | Closes behavior to what was previously implemented |
| 2 | PhImageCoherencyNormal | More comprehensive scan within reasonable limits |
| 3 or higher | PhImageCoherencyFull | Compete scan, may be slow in some situations |

