### PR TITLE
Improve dbghelp.dll finding on ARM64

### DIFF
--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -275,8 +275,10 @@ VOID PhpSymbolProviderCompleteInitialization(
         PPH_STRING dbghelpName;
         PPH_STRING symsrvName;
 
-#ifdef _WIN64
+#if defined(_M_AMD64)
         PhMoveReference(&winsdkPath, PhConcatStringRefZ(&winsdkPath->sr, L"\\Debuggers\\x64\\"));
+#elif defined(_M_ARM64)
+        PhMoveReference(&winsdkPath, PhConcatStringRefZ(&winsdkPath->sr, L"\\Debuggers\\arm64\\"));
 #else
         PhMoveReference(&winsdkPath, PhConcatStringRefZ(&winsdkPath->sr, L"\\Debuggers\\x86\\"));
 #endif


### PR DESCRIPTION
`PhpSymbolProviderCompleteInitialization` currently deals with the x64 and x86 cases to build the path to load `dbghelp.dll`, but due to the `_WIN64` ifdef, the x64 path will be tried on ARM64 as well even though it has a separate `arm64` directory in the SDK. This PR fixes this.

---

Note that thread stacks are currently far from optimal on ARM64 regardless of which dbghelp.dll is loaded. On my Raspberry Pi 4 with Insider Preview 10.0.21296.0 I get the following stacktrace using the System32 dbghelp:
![image](https://user-images.githubusercontent.com/3313892/106904647-ba19a780-66fb-11eb-878b-8f5335451a67.png)
(note the missing bottom frame, as well as no symbols being present due to the missing `symsrv.dll`)

Using the Windows 10.19041.0 SDK dbghelp/symsrv we do get the bottom frame - in fact, dbghelp likes it so much it doesn't want to stop repeating it:
![image](https://user-images.githubusercontent.com/3313892/106905162-49bf5600-66fc-11eb-9ae3-b1a776eb598e.png)
So both of these are pretty bad, but I still prefer the SDK dbghelp since at least it comes with correct symbol names.

I didn't make an issue for the above as I am getting equally bad stacktraces in WinDbg, so I assume this is a problem in dbghelp.dll and not Process Hacker.