### PR TITLE
Fix commit hash length & link About's hash to GitHub

### DIFF
--- a/ProcessHacker/about.c
+++ b/ProcessHacker/about.c
@@ -56,7 +56,7 @@ static INT_PTR CALLBACK PhpAboutDlgProc(
 
 #if (PHAPP_VERSION_REVISION != 0)
             appName = PhFormatString(
-                L"Process Hacker %lu.%lu.%lu (%hs)",
+                L"Process Hacker %lu.%lu.%lu (<a href=\"https://github.com/processhacker/processhacker/commit/%hs\">%hs</a>)",
                 PHAPP_VERSION_MAJOR,
                 PHAPP_VERSION_MINOR,
                 PHAPP_VERSION_REVISION,

--- a/tools/CustomBuildTool/Build.cs
+++ b/tools/CustomBuildTool/Build.cs
@@ -185,7 +185,7 @@ namespace CustomBuildTool
                 if (!string.IsNullOrEmpty(BuildCommit))
                 {
                     Program.PrintColorMessage(" (", ConsoleColor.DarkGray, false);
-                    Program.PrintColorMessage(BuildCommit.Substring(0, 8), ConsoleColor.DarkYellow, false);
+                    Program.PrintColorMessage(BuildCommit.Substring(0, 7), ConsoleColor.DarkYellow, false);
                     Program.PrintColorMessage(")", ConsoleColor.DarkGray, false);
                 }
 
@@ -835,7 +835,7 @@ namespace CustomBuildTool
                 if (Flags.HasFlag(BuildFlags.BuildApi))
                     compilerOptions.Append("PH_BUILD_API;");
                 if (!string.IsNullOrEmpty(BuildCommit))
-                    compilerOptions.Append($"PHAPP_VERSION_COMMITHASH=\"{BuildCommit.Substring(0, 8)}\";");
+                    compilerOptions.Append($"PHAPP_VERSION_COMMITHASH=\"{BuildCommit.Substring(0, 7)}\";");
                 if (!string.IsNullOrEmpty(BuildRevision))
                     compilerOptions.Append($"PHAPP_VERSION_REVISION=\"{BuildRevision}\";");
                 if (!string.IsNullOrEmpty(BuildCount))
@@ -869,7 +869,7 @@ namespace CustomBuildTool
                 if (Flags.HasFlag(BuildFlags.BuildApi))
                     compilerOptions.Append("PH_BUILD_API;");
                 if (!string.IsNullOrEmpty(BuildCommit))
-                    compilerOptions.Append($"PHAPP_VERSION_COMMITHASH=\"{BuildCommit.Substring(0, 8)}\";");
+                    compilerOptions.Append($"PHAPP_VERSION_COMMITHASH=\"{BuildCommit.Substring(0, 7)}\";");
                 if (!string.IsNullOrEmpty(BuildRevision))
                     compilerOptions.Append($"PHAPP_VERSION_REVISION=\"{BuildRevision}\";");
                 if (!string.IsNullOrEmpty(BuildCount))


### PR DESCRIPTION
@dmex I thought short commit hashes should be displayed equally correct & linking the version's last commit within the About dialog to its GitHub page (just like the Changelog listing of the Updater dialog does) would be a good idea - hence this PR.