### PR TITLE
Improve name generation for process and thread handles

### DIFF
--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -887,7 +887,7 @@ PPH_STRING PhStdGetClientIdNameEx(
     {
         LARGE_INTEGER timeout = { 0 };
 
-        // Waiting with zero timout checks for termination
+        // Waiting with zero timeout checks for termination
         if (NtWaitForSingleObject(processHandle, FALSE, &timeout) == STATUS_WAIT_0)
             isProcessTerminated = TRUE;
 

--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -836,95 +836,113 @@ _Callback_ PPH_STRING PhStdGetClientIdName(
     _In_ PCLIENT_ID ClientId
     )
 {
-    static PH_QUEUED_LOCK cachedProcessesLock = PH_QUEUED_LOCK_INIT;
-    static PVOID processes = NULL;
-    static ULONG64 lastProcessesTickCount = 0;
+    return PhStdGetClientIdNameEx(ClientId, NULL);
+}
 
-    PPH_STRING name;
-    ULONG64 tickCount;
-    PSYSTEM_PROCESS_INFORMATION processInfo;
+PPH_STRING PhStdGetClientIdNameEx(
+    _In_ PCLIENT_ID ClientId,
+    _In_opt_ PPH_STRING ProcessName
+    )
+{
+    PPH_STRING result;
+    PPH_STRING processName = NULL;
+    PPH_STRING threadName = NULL;
+    PH_STRINGREF processNameRef;
+    PH_STRINGREF threadNameRef;
+    HANDLE hProcess, hThread;
+    ULONG isProcessTerminated = FALSE;
+    ULONG isThreadTerminated = FALSE;
 
-    // Get a new process list only if 2 seconds have passed since the last update.
-    tickCount = NtGetTickCount64();
-
-    if (tickCount - lastProcessesTickCount >= 2000)
+    if (ProcessName)
     {
-        PhAcquireQueuedLockExclusive(&cachedProcessesLock);
-
-        // Re-check the tick count.
-        if (tickCount - lastProcessesTickCount >= 2000)
-        {
-            if (processes)
-            {
-                PhFree(processes);
-                processes = NULL;
-            }
-
-            if (!NT_SUCCESS(PhEnumProcesses(&processes)))
-            {
-                PhReleaseQueuedLockExclusive(&cachedProcessesLock);
-                return PhCreateString(L"(Error querying processes)");
-            }
-
-            lastProcessesTickCount = tickCount;
-        }
-
-        PhReleaseQueuedLockExclusive(&cachedProcessesLock);
-    }
-
-    // Get a lock on the process list and get a name for the client ID.
-
-    PhAcquireQueuedLockShared(&cachedProcessesLock);
-
-    if (!processes)
-    {
-        PhReleaseQueuedLockShared(&cachedProcessesLock);
-        return NULL;
-    }
-
-    processInfo = PhFindProcessInformation(processes, ClientId->UniqueProcess);
-
-    if (ClientId->UniqueThread)
-    {
-        if (processInfo)
-        {
-            name = PhFormatString(
-                L"%.*s (%lu): %lu",
-                processInfo->ImageName.Length / sizeof(WCHAR),
-                processInfo->ImageName.Buffer,
-                HandleToUlong(ClientId->UniqueProcess),
-                HandleToUlong(ClientId->UniqueThread)
-                );
-        }
-        else
-        {
-            name = PhFormatString(
-                L"Non-existent process (%lu): %lu",
-                HandleToUlong(ClientId->UniqueProcess),
-                HandleToUlong(ClientId->UniqueThread)
-                );
-        }
+        // Use the supplied name
+        processNameRef.Length = ProcessName->Length;
+        processNameRef.Buffer = ProcessName->Buffer;
     }
     else
     {
-        if (processInfo)
+        // Determine the name of the process ourselves
+        if (NT_SUCCESS(PhGetProcessImageFileNameById(
+            ClientId->UniqueProcess,
+            NULL,
+            &processName
+            )))
         {
-            name = PhFormatString(
-                L"%.*s (%lu)",
-                processInfo->ImageName.Length / sizeof(WCHAR),
-                processInfo->ImageName.Buffer,
-                HandleToUlong(ClientId->UniqueProcess)
-                );
+            processNameRef.Length = processName->Length;
+            processNameRef.Buffer = processName->Buffer;
         }
         else
         {
-            name = PhFormatString(L"Non-existent process (%lu)", HandleToUlong(ClientId->UniqueProcess));
+            PhInitializeStringRef(&processNameRef, L"Unknown process");
         }
     }
 
-    PhReleaseQueuedLockShared(&cachedProcessesLock);
+    // Check if the process is alive, but only if we didn't get its name
+    if (!ProcessName && NT_SUCCESS(PhOpenProcess(
+        &hProcess,
+        SYNCHRONIZE,
+        ClientId->UniqueProcess
+        )))
+    {
+        LARGE_INTEGER timeout = { 0 };
 
-    return name;
+        // Waiting with zero timout checks for termination
+        if (NtWaitForSingleObject(hProcess, FALSE, &timeout) == STATUS_WAIT_0)
+            isProcessTerminated = TRUE;
+
+        NtClose(hProcess);
+    }
+
+    PhInitializeStringRef(&threadNameRef, L"unnamed thread");
+
+    if (ClientId->UniqueThread)
+    {
+        if (NT_SUCCESS(PhOpenThread(
+            &hThread,
+            THREAD_QUERY_LIMITED_INFORMATION,
+            ClientId->UniqueThread
+            )))
+        {
+            // Check if the thread is alive
+            NtQueryInformationThread(
+                hThread,
+                ThreadIsTerminated,
+                &isThreadTerminated,
+                sizeof(ULONG),
+                NULL
+                );
+
+            // Use the name of the thread if available
+            if (NT_SUCCESS(PhGetThreadName(hThread, &threadName)) && threadName->Length)
+            {
+                threadNameRef.Length = threadName->Length;
+                threadNameRef.Buffer = threadName->Buffer;
+            }
+
+            NtClose(hThread);
+        }
+    }
+
+    // Combine everything
+    result = PhFormatString(
+        ClientId->UniqueThread ? L"%s%.*s (%lu): %s%.*s (%lu)" : L"%s%.*s (%lu)",
+        isProcessTerminated ? L"Terminated " : L"",
+        processNameRef.Length / sizeof(WCHAR),
+        processNameRef.Buffer,
+        HandleToUlong(ClientId->UniqueProcess),
+        isThreadTerminated ? L"terminated " : L"",
+        threadNameRef.Length / sizeof(WCHAR),
+        threadNameRef.Buffer,
+        HandleToUlong(ClientId->UniqueThread)
+        );
+
+    if (processName)
+        PhDereferenceObject(processName);
+
+    if (threadName)
+        PhDereferenceObject(threadName);
+
+    return result;
 }
 
 NTSTATUS PhpGetBestObjectName(

--- a/phlib/include/hndlinfo.h
+++ b/phlib/include/hndlinfo.h
@@ -48,6 +48,14 @@ PhStdGetClientIdName(
     );
 
 PHLIBAPI
+PPH_STRING
+NTAPI
+PhStdGetClientIdNameEx(
+    _In_ PCLIENT_ID ClientId,
+    _In_opt_ PPH_STRING ProcessName
+    );
+
+PHLIBAPI
 NTSTATUS
 NTAPI
 PhGetHandleInformation(

--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -206,6 +206,15 @@ PhGetProcessImageFileNameWin32(
 PHLIBAPI
 NTSTATUS
 NTAPI
+PhGetProcessImageFileNameById(
+    _In_ HANDLE ProcessId,
+    _Out_opt_ PPH_STRING *FullFileName,
+    _Out_opt_ PPH_STRING *FileName
+    );
+
+PHLIBAPI
+NTSTATUS
+NTAPI
 PhGetProcessIsBeingDebugged(
     _In_ HANDLE ProcessHandle,
     _Out_ PBOOLEAN IsBeingDebugged


### PR DESCRIPTION
Since it is possible to determine image names for processes without snapshotting or opening handles, I decided to reorganize the logic behind `PhStdGetClientIdName` and `PhGetClientIdName`. The new implementation does not invoke additional snapshotting and does not suffer from not finding freshly created processes in the snapshots. I also adjusted the output to use thread names (when available) and indicate termination state.

![image](https://user-images.githubusercontent.com/30962924/109407452-39a83880-7981-11eb-8991-0773f5c25cb2.png)

As a bonus, now you can also search for programs that leak handles to terminated threads and processes:

![image](https://user-images.githubusercontent.com/30962924/109407440-167d8900-7981-11eb-8241-c9a7ca68448f.png)