### PR TITLE
PhLoadLibrarySafe and ban LoadLibrary

### DIFF
--- a/ProcessHacker/ProcessHacker.def
+++ b/ProcessHacker/ProcessHacker.def
@@ -420,6 +420,7 @@ EXPORTS
     PhShowStatus
     PhStringToGuid
     PhUpdateHash
+    PhLoadLibrarySafe
 
 ; circbuf
     PhClearCircularBuffer_FLOAT

--- a/ProcessHacker/phsvc/svcapi.c
+++ b/ProcessHacker/phsvc/svcapi.c
@@ -1130,7 +1130,7 @@ NTSTATUS PhSvcApiSetTcpEntry(
     {
         HMODULE iphlpapiModule;
 
-        iphlpapiModule = LoadLibrary(L"iphlpapi.dll");
+        iphlpapiModule = PhLoadLibrarySafe(L"iphlpapi.dll");
 
         if (iphlpapiModule)
         {

--- a/ProcessHacker/prpgwmi.c
+++ b/ProcessHacker/prpgwmi.c
@@ -66,7 +66,7 @@ PVOID PhpGetWmiProviderDllBase(
             if (systemFileName = PhConcatStringRefZ(&systemDirectory->sr, L"\\wbem\\wbemprox.dll"))
             {
                 if (!(imageBaseAddress = PhGetLoaderEntryFullDllBase(PhGetString(systemFileName))))
-                    imageBaseAddress = LoadLibrary(PhGetString(systemFileName));
+                    imageBaseAddress = PhLoadLibrarySafe(PhGetString(systemFileName));
 
                 PhDereferenceObject(systemFileName);
             }

--- a/ProcessHacker/runas.c
+++ b/ProcessHacker/runas.c
@@ -231,7 +231,7 @@ BOOLEAN PhShowRunFileDialog(
     //    );
     //PVOID shell32Handle;
     //
-    //if (shell32Handle = LoadLibrary(L"shell32.dll"))
+    //if (shell32Handle = PhLoadLibrarySafe(L"shell32.dll"))
     //{
     //    if (RunFileDlg_I = PhGetDllBaseProcedureAddress(shell32Handle, NULL, 61))
     //    {
@@ -387,7 +387,7 @@ BOOLEAN PhpInitializeNetApi(VOID)
 
     if (PhBeginInitOnce(&initOnce))
     {
-        if (netapiModuleHandle = LoadLibrary(L"netapi32.dll"))
+        if (netapiModuleHandle = PhLoadLibrarySafe(L"netapi32.dll"))
         {
             NetUserEnum_I = PhGetDllBaseProcedureAddress(netapiModuleHandle, "NetUserEnum", 0);
             NetApiBufferFree_I = PhGetDllBaseProcedureAddress(netapiModuleHandle, "NetApiBufferFree", 0);
@@ -415,7 +415,7 @@ BOOLEAN PhpInitializeMRUList(VOID)
 
     if (PhBeginInitOnce(&initOnce))
     {
-        if (comctl32ModuleHandle = LoadLibrary(L"comctl32.dll"))
+        if (comctl32ModuleHandle = PhLoadLibrarySafe(L"comctl32.dll"))
         {
             CreateMRUList_I = PhGetDllBaseProcedureAddress(comctl32ModuleHandle, "CreateMRUListW", 0);
             AddMRUString_I = PhGetDllBaseProcedureAddress(comctl32ModuleHandle, "AddMRUStringW", 0);
@@ -2095,7 +2095,7 @@ BOOLEAN PhpRunFileAsInteractiveUser(
     INT cmdlineArgCount;
     PWSTR* cmdlineArgList;
 
-    if (!(wdcLibraryHandle = LoadLibrary(L"wdc.dll")))
+    if (!(wdcLibraryHandle = PhLoadLibrarySafe(L"wdc.dll")))
         return FALSE;
 
     if (!(WdcRunTaskAsInteractiveUser_I = PhGetDllBaseProcedureAddress(wdcLibraryHandle, "WdcRunTaskAsInteractiveUser", 0)))

--- a/ProcessHacker/sdk/phdk.h
+++ b/ProcessHacker/sdk/phdk.h
@@ -6,6 +6,7 @@
 #define PHNT_VERSION PHNT_WIN7
 #define PHAPPAPI __declspec(dllimport)
 
+#include "banned.h"
 #include "ph.h"
 #include "phnet.h"
 #include "provider.h"

--- a/ProcessHacker/srvprv.c
+++ b/ProcessHacker/srvprv.c
@@ -1377,7 +1377,7 @@ VOID PhpInitializeServiceNonPoll(
     {
         PVOID sechostHandle;
 
-        if (sechostHandle = LoadLibrary(L"sechost.dll"))
+        if (sechostHandle = PhLoadLibrarySafe(L"sechost.dll"))
         {
             SubscribeServiceChangeNotifications_I = PhGetDllBaseProcedureAddress(sechostHandle, "SubscribeServiceChangeNotifications", 0);
             UnsubscribeServiceChangeNotifications_I = PhGetDllBaseProcedureAddress(sechostHandle, "UnsubscribeServiceChangeNotifications", 0);

--- a/phlib/apiimport.c
+++ b/phlib/apiimport.c
@@ -41,7 +41,7 @@ PVOID PhpImportProcedure(
         module = PhGetLoaderEntryDllBase(ModuleName);
 
         if (!module)
-            module = LoadLibrary(ModuleName);
+            module = PhLoadLibrarySafe(ModuleName);
 
         if (module)
         {

--- a/phlib/appresolver.c
+++ b/phlib/appresolver.c
@@ -82,7 +82,7 @@ static BOOLEAN PhpKernelAppCoreInitialized(
         {
             PVOID kernelBaseModuleHandle;
 
-            if (kernelBaseModuleHandle = LoadLibrary(L"kernelbase.dll")) // kernel.appcore.dll
+            if (kernelBaseModuleHandle = PhLoadLibrarySafe(L"kernelbase.dll")) // kernel.appcore.dll
             {
                 AppContainerDeriveSidFromMoniker_I = PhGetDllBaseProcedureAddress(kernelBaseModuleHandle, "AppContainerDeriveSidFromMoniker", 0);
                 AppContainerLookupMoniker_I = PhGetDllBaseProcedureAddress(kernelBaseModuleHandle, "AppContainerLookupMoniker", 0);

--- a/phlib/guisup.c
+++ b/phlib/guisup.c
@@ -1715,7 +1715,7 @@ HICON PhGetInternalWindowIcon(
     {
         PVOID shell32Handle;
 
-        if (shell32Handle = LoadLibrary(L"shell32.dll"))
+        if (shell32Handle = PhLoadLibrarySafe(L"shell32.dll"))
         {
             InternalGetWindowIcon_I = PhGetDllBaseProcedureAddress(shell32Handle, "InternalGetWindowIcon", 0);
         }

--- a/phlib/hndlinfo.c
+++ b/phlib/hndlinfo.c
@@ -607,7 +607,7 @@ PPH_STRING PhGetPnPDeviceName(
     {
         PVOID cfgmgr32;
 
-        if (cfgmgr32 = LoadLibrary(L"cfgmgr32.dll"))
+        if (cfgmgr32 = PhLoadLibrarySafe(L"cfgmgr32.dll"))
         {
             DevGetObjects_I = PhGetDllBaseProcedureAddress(cfgmgr32, "DevGetObjects", 0);
             DevFreeObjects_I = PhGetDllBaseProcedureAddress(cfgmgr32, "DevFreeObjects", 0);

--- a/phlib/include/banned.h
+++ b/phlib/include/banned.h
@@ -1,0 +1,24 @@
+#pragma once
+
+//
+// These functions are banned in process hacker and associated plug-ins.
+//
+
+__declspec(deprecated("LoadLibraryA is banned, use PsLoadLibrarySafe instead (see: banned.h)."))
+WINBASEAPI
+_Ret_maybenull_
+HMODULE
+WINAPI
+LoadLibraryA(
+    _In_ LPCSTR lpLibFileName
+    );
+
+__declspec(deprecated("LoadLibraryW is banned, use PsLoadLibrarySafe instead (see: banned.h)."))
+WINBASEAPI
+_Ret_maybenull_
+HMODULE
+WINAPI
+LoadLibraryW(
+    _In_ LPCWSTR lpLibFileName
+    );
+

--- a/phlib/include/phbase.h
+++ b/phlib/include/phbase.h
@@ -22,6 +22,7 @@
 #endif
 
 #include <phnt_windows.h>
+#include <banned.h>
 #include <phnt.h>
 #include <phsup.h>
 #include <ref.h>

--- a/phlib/include/phutil.h
+++ b/phlib/include/phutil.h
@@ -1479,6 +1479,13 @@ PhGetClassObject(
     _Out_ PVOID* Ppv
     );
 
+PHLIBAPI
+_Ret_maybenull_
+HMODULE
+PhLoadLibrarySafe(
+    _In_ PCWSTR LibFileName
+    );
+
 #ifdef __cplusplus
 }
 #endif

--- a/phlib/secedit.c
+++ b/phlib/secedit.c
@@ -1596,7 +1596,7 @@ PVOID PhpInitializePowerPolicyApi(VOID)
 
     if (PhBeginInitOnce(&initOnce))
     {
-        imageBaseAddress = LoadLibrary(L"powrprof.dll");
+        imageBaseAddress = PhLoadLibrarySafe(L"powrprof.dll");
         PhEndInitOnce(&initOnce);
     }
 
@@ -1734,7 +1734,7 @@ PVOID PhpInitializeRemoteDesktopServiceApi(VOID)
 
     if (PhBeginInitOnce(&initOnce))
     {
-        imageBaseAddress = LoadLibrary(L"wtsapi32.dll");
+        imageBaseAddress = PhLoadLibrarySafe(L"wtsapi32.dll");
         PhEndInitOnce(&initOnce);
     }
 
@@ -1856,7 +1856,7 @@ PVOID PhGetWbemProxDllBase(
             if (systemFileName = PhConcatStringRefZ(&systemDirectory->sr, L"\\wbem\\wbemprox.dll"))
             {
                 if (!(imageBaseAddress = PhGetLoaderEntryFullDllBase(PhGetString(systemFileName))))
-                    imageBaseAddress = LoadLibrary(PhGetString(systemFileName));
+                    imageBaseAddress = PhLoadLibrarySafe(PhGetString(systemFileName));
 
                 PhDereferenceObject(systemFileName);
             }

--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -285,13 +285,13 @@ VOID PhpSymbolProviderCompleteInitialization(
 
         if (dbghelpName = PhConcatStringRef2(&winsdkPath->sr, &dbghelpFileName))
         {
-            dbghelpHandle = LoadLibrary(dbghelpName->Buffer);
+            dbghelpHandle = PhLoadLibrarySafe(dbghelpName->Buffer);
             PhDereferenceObject(dbghelpName);
         }
 
         if (symsrvName = PhConcatStringRef2(&winsdkPath->sr, &symsrvFileName))
         {
-            symsrvHandle = LoadLibrary(symsrvName->Buffer);
+            symsrvHandle = PhLoadLibrarySafe(symsrvName->Buffer);
             PhDereferenceObject(symsrvName);
         }
 
@@ -299,10 +299,10 @@ VOID PhpSymbolProviderCompleteInitialization(
     }
 
     if (!dbghelpHandle)
-        dbghelpHandle = LoadLibrary(L"dbghelp.dll");
+        dbghelpHandle = PhLoadLibrarySafe(L"dbghelp.dll");
 
     if (!symsrvHandle)
-        symsrvHandle = LoadLibrary(L"symsrv.dll");
+        symsrvHandle = PhLoadLibrarySafe(L"symsrv.dll");
 
     if (dbghelpHandle)
     {

--- a/phlib/theme.c
+++ b/phlib/theme.c
@@ -184,14 +184,14 @@ VOID PhInitializeWindowTheme(
         {
             PVOID module;
 
-            if (module = LoadLibrary(L"dwmapi.dll"))
+            if (module = PhLoadLibrarySafe(L"dwmapi.dll"))
             {
                 DwmSetWindowAttribute_I = PhGetDllBaseProcedureAddress(module, "DwmSetWindowAttribute", 0);
             }
 
             if (WindowsVersion >= WINDOWS_10_19H2)
             {
-                if (module = LoadLibrary(L"uxtheme.dll"))
+                if (module = PhLoadLibrarySafe(L"uxtheme.dll"))
                 {
                     AllowDarkModeForWindow_I = PhGetDllBaseProcedureAddress(module, NULL, 133);
                     SetPreferredAppMode_I = PhGetDllBaseProcedureAddress(module, NULL, 135);

--- a/phlib/verify.c
+++ b/phlib/verify.c
@@ -57,8 +57,8 @@ static VOID PhpVerifyInitialization(
     HMODULE wintrust;
     HMODULE crypt32;
 
-    wintrust = LoadLibrary(L"wintrust.dll");
-    crypt32 = LoadLibrary(L"crypt32.dll");
+    wintrust = PhLoadLibrarySafe(L"wintrust.dll");
+    crypt32 = PhLoadLibrarySafe(L"crypt32.dll");
 
     if (wintrust)
     {
@@ -179,7 +179,7 @@ VOID PhpViewSignerInfo(
     {
         HMODULE cryptui;
 
-        if (cryptui = LoadLibrary(L"cryptui.dll"))
+        if (cryptui = PhLoadLibrarySafe(L"cryptui.dll"))
         {
             cryptUIDlgViewSignerInfo = PhGetDllBaseProcedureAddress(cryptui, "CryptUIDlgViewSignerInfoW", 0);
         }

--- a/plugins/DotNetTools/clrsup.c
+++ b/plugins/DotNetTools/clrsup.c
@@ -189,7 +189,7 @@ PVOID LoadMscordacwks(
     PH_STRINGREF mscordacwksPathString;
     PPH_STRING mscordacwksFileName;
 
-    LoadLibrary(L"mscoree.dll");
+    PhLoadLibrarySafe(L"mscoree.dll");
 
     PhGetSystemRoot(&systemRootString);
 
@@ -211,7 +211,7 @@ PVOID LoadMscordacwks(
     }
 
     mscordacwksFileName = PhConcatStringRef2(&systemRootString, &mscordacwksPathString);
-    dllBase = LoadLibrary(mscordacwksFileName->Buffer);
+    dllBase = PhLoadLibrarySafe(mscordacwksFileName->Buffer);
     PhDereferenceObject(mscordacwksFileName);
 
     return dllBase;

--- a/plugins/ExtendedTools/fwmon.c
+++ b/plugins/ExtendedTools/fwmon.c
@@ -1638,7 +1638,7 @@ ULONG EtFwMonitorInitialize(
         20
         );
 
-    if (!(baseAddress = LoadLibrary(L"fwpuclnt.dll")))
+    if (!(baseAddress = PhLoadLibrarySafe(L"fwpuclnt.dll")))
         return GetLastError();
     if (!FwpmNetEventSubscribe_I)
         FwpmNetEventSubscribe_I = PhGetProcedureAddress(baseAddress, "FwpmNetEventSubscribe4", 0);

--- a/plugins/ExtendedTools/gpumon.c
+++ b/plugins/ExtendedTools/gpumon.c
@@ -463,8 +463,8 @@ D3D_FEATURE_LEVEL EtQueryAdapterFeatureLevel(
 
     if (PhBeginInitOnce(&initOnce))
     {
-        LoadLibrary(L"dxgi.dll");
-        LoadLibrary(L"d3d11.dll");
+        PhLoadLibrarySafe(L"dxgi.dll");
+        PhLoadLibrarySafe(L"d3d11.dll");
         CreateDXGIFactory1_I = PhGetModuleProcAddress(L"dxgi.dll", "CreateDXGIFactory1");
         D3D11CreateDevice_I = PhGetModuleProcAddress(L"d3d11.dll", "D3D11CreateDevice");
 

--- a/plugins/HardwareDevices/main.c
+++ b/plugins/HardwareDevices/main.c
@@ -267,7 +267,7 @@ BOOLEAN HardwareDeviceShowProperties(
     //    _In_opt_ PWSTR MachineName,
     //    _In_ PWSTR DeviceID);
 
-    if (devMgrHandle = LoadLibrary(L"devmgr.dll"))
+    if (devMgrHandle = PhLoadLibrarySafe(L"devmgr.dll"))
     {
         if (DeviceProperties_RunDLL_I = PhGetProcedureAddress(devMgrHandle, "DeviceProperties_RunDLLW", 0))
         {

--- a/plugins/HardwareDevices/ndis.c
+++ b/plugins/HardwareDevices/ndis.c
@@ -179,7 +179,7 @@ PPH_STRING NetworkAdapterQueryNameFromGuid(
     {
         PVOID iphlpHandle;
 
-        if (iphlpHandle = LoadLibrary(L"iphlpapi.dll"))
+        if (iphlpHandle = PhLoadLibrarySafe(L"iphlpapi.dll"))
         {
             NhGetInterfaceDescriptionFromGuid_I = PhGetProcedureAddress(iphlpHandle, "NhGetInterfaceDescriptionFromGuid", 0);
         }
@@ -261,7 +261,7 @@ PPH_STRING NetworkAdapterGetInterfaceAliasFromGuid(
     {
         PVOID iphlpHandle;
 
-        if (iphlpHandle = LoadLibrary(L"iphlpapi.dll"))
+        if (iphlpHandle = PhLoadLibrarySafe(L"iphlpapi.dll"))
         {
             NhGetInterfaceNameFromGuid_I = PhGetProcedureAddress(iphlpHandle, "NhGetInterfaceDescriptionFromGuid", 0);
         }

--- a/plugins/NetworkTools/whois.c
+++ b/plugins/NetworkTools/whois.c
@@ -817,7 +817,7 @@ NTSTATUS NetworkWhoisDialogThreadStart(
 
     if (PhBeginInitOnce(&initOnce))
     {
-        LoadLibrary(L"msftedit.dll");
+        PhLoadLibrarySafe(L"msftedit.dll");
         PhEndInitOnce(&initOnce);
     }
 

--- a/plugins/WindowExplorer/wndprp.c
+++ b/plugins/WindowExplorer/wndprp.c
@@ -832,7 +832,7 @@ static BOOLEAN WepWindowHasAutomationProvider(
     {
         HANDLE moduleHandle;
 
-        if (moduleHandle = LoadLibrary(L"uiautomationcore.dll"))
+        if (moduleHandle = PhLoadLibrarySafe(L"uiautomationcore.dll"))
         {
             UiaHasServerSideProvider_I = PhGetProcedureAddress(moduleHandle, "UiaHasServerSideProvider", 0);
         }

--- a/tools/CustomBuildTool/config.cs
+++ b/tools/CustomBuildTool/config.cs
@@ -139,7 +139,8 @@ namespace CustomBuildTool
             "templ.h",
             "treenew.h",
             "verify.h",
-            "workqueue.h"
+            "workqueue.h",
+            "banned.h"
         };
     }
 }

--- a/tools/peview/clrprp.c
+++ b/tools/peview/clrprp.c
@@ -270,7 +270,7 @@ VOID PvpGetClrStrongNameToken(
     ULONG size = MAX_PATH;
     WCHAR version[MAX_PATH] = L"";
 
-    if (mscoreeHandle = LoadLibrary(L"mscoree.dll"))
+    if (mscoreeHandle = PhLoadLibrarySafe(L"mscoree.dll"))
     {
         if (CLRCreateInstance_I = PhGetDllBaseProcedureAddress(mscoreeHandle, "CLRCreateInstance", 0))
         {


### PR DESCRIPTION
This PR deprecates `LoadLibrary` from use in Process Hacker and its associated plugins. `PhLoadLibrarySafe` is implemented as a replacement.

There is a sister PR to update `plugins-extra` here: https://github.com/processhacker/plugins-extra/pull/88