### PR TITLE
Add SSDEEP and TLSH to peview sections tab

### DIFF
--- a/tools/peview/tlsh/tlsh_wrapper.cpp
+++ b/tools/peview/tlsh/tlsh_wrapper.cpp
@@ -21,6 +21,7 @@
  */
 
 #include <ph.h>
+#include <memory>
 #include "tlsh.h"
 #include "tlsh_wrapper.h"
 
@@ -35,7 +36,7 @@ BOOLEAN PvGetTlshBufferHash(
     if (BufferLength < MIN_DATA_LENGTH)
         return FALSE;
 
-    Tlsh* tlshHash = new Tlsh();
+    auto tlshHash = std::make_unique<Tlsh>();
 
     if (BufferLength >= UINT_MAX)
     {
@@ -112,7 +113,7 @@ BOOLEAN PvGetTlshFileHash(
     if (!NT_SUCCESS(status))
         return FALSE;
 
-    Tlsh* tlshHash = new Tlsh();
+    auto tlshHash = std::make_unique<Tlsh>();
 
     bytesRemaining = fileSize.QuadPart;
 


### PR DESCRIPTION
This PR adds SSDEEP and TLSH to Sections tab in peview:
![image](https://user-images.githubusercontent.com/11687482/111890436-e6893a80-89ae-11eb-9ab3-604a7f0dd03e.png)

Note that TLSH can fail here when more than 50% of the buckets are empty during the hash calculation. This is a limitation of the library.