### PR TITLE
Fix module list image coherency view

### DIFF
--- a/ProcessHacker/modlist.c
+++ b/ProcessHacker/modlist.c
@@ -1066,10 +1066,13 @@ BOOLEAN NTAPI PhpModuleTreeNewCallback(
                             break;
                         }
 
-                        if (moduleItem->ImageCoherencyStatus != STATUS_SUCCESS)
+                        if (!PhShouldShowModuleCoherency(moduleItem, FALSE))
                         {
-                            PhMoveReference(&node->ImageCoherencyText, PhGetStatusMessage(moduleItem->ImageCoherencyStatus, 0));
-                            getCellText->Text = PhGetStringRef(node->ImageCoherencyText);
+                            if (moduleItem->ImageCoherencyStatus != STATUS_SUCCESS)
+                            {
+                                PhMoveReference(&node->ImageCoherencyText, PhGetStatusMessage(moduleItem->ImageCoherencyStatus, 0));
+                                getCellText->Text = PhGetStringRef(node->ImageCoherencyText);
+                            }
                             break;
                         }
 


### PR DESCRIPTION
This PR fixes the module list view image coherency to show properly for .NET modules.

![image](https://user-images.githubusercontent.com/11687482/112069138-e749da00-8b30-11eb-9513-ccbe503b0d70.png)
