### PR TITLE
Fixed relocation tab symbol resolution

### DIFF
--- a/phlib/include/mapimg.h
+++ b/phlib/include/mapimg.h
@@ -799,7 +799,8 @@ typedef struct _PH_IMAGE_RELOC_ENTRY
     ULONG BlockRva;
     ULONG Type;
     ULONG Offset;
-    PVOID Value;
+    PVOID ImageBaseVa;
+    PVOID MappedImageVa;
 } PH_IMAGE_RELOC_ENTRY, *PPH_IMAGE_RELOC_ENTRY;
 
 typedef struct _PH_MAPPED_IMAGE_RELOC

--- a/phlib/mapimg.c
+++ b/phlib/mapimg.c
@@ -3060,8 +3060,10 @@ NTSTATUS PhGetMappedImageRelocations(
             entry.BlockIndex = relocationIndex;
             entry.Type = relocations[i].Type;
             entry.Offset = relocations[i].Offset;
-            entry.Value = PTR_ADD_OFFSET(relocationAddress, relocations[i].Offset);
+            entry.MappedImageVa = PTR_ADD_OFFSET(relocationAddress, relocations[i].Offset);
             entry.BlockRva = relocationDirectory->VirtualAddress;
+            entry.ImageBaseVa = PTR_ADD_OFFSET(MappedImage->NtHeaders->OptionalHeader.ImageBase,
+                                               (SIZE_T)entry.BlockRva + entry.Offset);
             PhAddItemArray(&relocationArray, &entry);
         }
 


### PR DESCRIPTION
This PR fixes the relocation symbol resolution for the relocations tab of PE view. It also ads a field to the relocation block to clarify the VA.