### PR TITLE
Fix setting type of IconIgnoreBalloonClick

### DIFF
--- a/ProcessHacker/settings.c
+++ b/ProcessHacker/settings.c
@@ -94,7 +94,7 @@ VOID PhAddDefaultSettings(
     PhpAddIntegerSetting(L"HideWaitingConnections", L"0");
     PhpAddIntegerSetting(L"HighlightingDuration", L"3e8"); // 1000ms
     PhpAddStringSetting(L"IconGuids", L"");
-    PhpAddStringSetting(L"IconIgnoreBalloonClick", L"0");
+    PhpAddIntegerSetting(L"IconIgnoreBalloonClick", L"0");
     PhpAddStringSetting(L"IconSettings", L"1|1");
     PhpAddIntegerSetting(L"IconNotifyMask", L"c"); // PH_NOTIFY_SERVICE_CREATE | PH_NOTIFY_SERVICE_DELETE
     PhpAddIntegerSetting(L"IconProcesses", L"f"); // 15


### PR DESCRIPTION
In the recent commit https://github.com/processhacker/processhacker/commit/c2216c7e5958a81d77ec3621aac2e915232e6b4f that adds the `IconIgnoreBalloonClick` setting there is a type mismatch, since the setting is added with `PhpAddStringSetting` but read with `PhGetIntegerSetting`.
https://github.com/processhacker/processhacker/blob/5387c70cc9b5afea58f5748f0bb78a6c35568162/ProcessHacker/settings.c#L97
https://github.com/processhacker/processhacker/blob/5387c70cc9b5afea58f5748f0bb78a6c35568162/ProcessHacker/notifico.c#L412-L415

This causes intermittent crashes when clicking on the tray icon, due to an unhandled `STATUS_NOT_FOUND` exception raised in `PhGetIntegerSetting`.

This PR should fix the issue by changing `PhpAddStringSetting` to `PhpAddIntegerSetting` when adding the new setting.