### PR TITLE
Correctly show errors in module list for failed imgcoherency

### DIFF
--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -4119,18 +4119,41 @@ BOOLEAN PhpShouldShowImageCoherency(
         (ProcessItem->ImageCoherencyStatus == STATUS_INVALID_IMAGE_HASH) ||
         (ProcessItem->ImageCoherencyStatus == STATUS_IMAGE_SUBSYSTEM_NOT_PRESENT))
     {
+        //
+        // The coherency status is a success code or a known "valid" error
+        // from the coherency calculation (PhGetProcessImageCoherency).
+        // We should show the coherency value.
+        //
+
         if (CheckThreshold)
         {
+            //
+            // A threshold check is requested. This is generally used for
+            // checking if we should highlight an entry. If the coherency
+            // is below a given threshold return true. Otherwise false.
+            //
             if (ProcessItem->ImageCoherency <= LowImageCoherencyThreshold)
             {
                 return TRUE;
             }
+            else
+            {
+                return FALSE;
+            }
+
         }
-        else
-        {
-            return TRUE;
-        }
+
+        //
+        // No special handling, return true.
+        //
+        return TRUE;
     }
+
+    //
+    // Any other error NTSTATUS we don't show the coherency value, we'll
+    // show the reason why we failed the calculation (a string representation
+    // of the status code).
+    //
 
     return FALSE;
 }


### PR DESCRIPTION
This PR fixes the module list to show imgcoherency errors properly

![image](https://user-images.githubusercontent.com/11687482/113789874-43018f00-96fd-11eb-85e3-930679ed3926.png)

I've also added some comments around those areas to clarify what's happening. Using failure NTSTATUS codes for "partial" or "inherently incoherent" calculations was probably a poor choice and could be rectified to clear things up a bit. In the meantime this patch will correctly show "access denied" for modules in processes whose memory we can't access.