### PR TITLE
Fix for KnownDLL extents lookup on 21H2

### DIFF
--- a/KProcessHacker/include/ntfill.h
+++ b/KProcessHacker/include/ntfill.h
@@ -410,4 +410,8 @@ NTSTATUS
     _Out_ PIMAGE_NT_HEADERS* OutHeaders
     );
 
+// MM
+
+extern POBJECT_TYPE *MmSectionObjectType;
+
 #endif


### PR DESCRIPTION
Fix for issue: https://github.com/processhacker/processhacker/issues/898

Due to the changes on 21H2 we'll instead leverage `MmMapViewInSystemSpace` to resolve the module extents.

One stipulation, if this change is a precursor to Microsoft relocating ntdll in all processes we'll have to revisit this. But, for now this will resolve the issue.