### PR TITLE
Add support for kernel CET

### DIFF
--- a/ProcessHacker/include/modprv.h
+++ b/ProcessHacker/include/modprv.h
@@ -77,7 +77,8 @@ typedef struct _PH_MODULE_PROVIDER
             BOOLEAN ControlFlowGuardEnabled : 1;
             BOOLEAN IsSubsystemProcess : 1;
             BOOLEAN CetEnabled : 1;
-            BOOLEAN Spare : 4;
+            BOOLEAN CetStrictModeEnabled : 1;
+            BOOLEAN Spare : 3;
         };
     };
     UCHAR ImageCoherencyScanLevel;

--- a/ProcessHacker/modprv.c
+++ b/ProcessHacker/modprv.c
@@ -170,10 +170,12 @@ PPH_MODULE_PROVIDER PhCreateModuleProvider(
         if (WindowsVersion >= WINDOWS_10_20H1)
         {
             BOOLEAN cetEnabled;
+            BOOLEAN cetStrictModeEnabled;
 
-            if (NT_SUCCESS(PhGetProcessIsCetEnabled(moduleProvider->ProcessHandle, &cetEnabled)))
+            if (NT_SUCCESS(PhGetProcessIsCetEnabled(moduleProvider->ProcessHandle, &cetEnabled, &cetStrictModeEnabled)))
             {
                 moduleProvider->CetEnabled = cetEnabled;
+                moduleProvider->CetStrictModeEnabled = cetStrictModeEnabled;
             }
         }
     }
@@ -760,6 +762,10 @@ VOID PhModuleProviderUpdate(
             // remove CF Guard flag if CFG mitigation is not enabled for the process
             if (!moduleProvider->ControlFlowGuardEnabled)
                 moduleItem->ImageDllCharacteristics &= ~IMAGE_DLLCHARACTERISTICS_GUARD_CF;
+
+            // if process has strict mode enabled add CET flag to module
+            if (moduleProvider->CetStrictModeEnabled)
+                moduleItem->ImageDllCharacteristicsEx |= IMAGE_DLLCHARACTERISTICS_EX_CET_COMPAT;
 
             // remove CET flag if CET is not enabled for the process
             if (!moduleProvider->CetEnabled)

--- a/ProcessHacker/procprv.c
+++ b/ProcessHacker/procprv.c
@@ -1331,7 +1331,7 @@ VOID PhpFillProcessItem(
     {
         BOOLEAN cetEnabled;
 
-        if (NT_SUCCESS(PhGetProcessIsCetEnabled(ProcessItem->QueryHandle, &cetEnabled)))
+        if (NT_SUCCESS(PhGetProcessIsCetEnabled(ProcessItem->QueryHandle, &cetEnabled, NULL)))
         {
             ProcessItem->IsCetEnabled = cetEnabled;
         }


### PR DESCRIPTION
This change will add support for kernel CET on systems that support it.

Process tree
![image](https://user-images.githubusercontent.com/5801389/119802170-9f538480-bede-11eb-83b5-4271889772fe.png)

Process mitigations
![image](https://user-images.githubusercontent.com/5801389/119802458-d5910400-bede-11eb-95f4-21df74d1de37.png)

Process modules
![image](https://user-images.githubusercontent.com/5801389/119802270-b4301800-bede-11eb-91da-716261ca3e5c.png)

Change is pretty simple, but contains two potential problems:

1. Detecting System process by PID, I don't really like it and I'm welcome to ideas
2. Populating `UserShadowStack` in `PhGetProcessMitigationPolicy` with data retrived using `NtQuerySystemInformation`.

