### PR TITLE
Fix a thread handle leak in the Process window Threads tab

### DIFF
--- a/ProcessHacker/prpgthrd.c
+++ b/ProcessHacker/prpgthrd.c
@@ -182,6 +182,8 @@ VOID PhpInitializeThreadMenu(
                     PhSetFlagsEMenuItem(Menu, ID_THREAD_CRITICAL, PH_EMENU_CHECKED, PH_EMENU_CHECKED);
                 }
             }
+
+            NtClose(threadHandle);
         }
     }
 


### PR DESCRIPTION
Pretty sure this is a thread handle leak. The other code paths (e.g. for priority) call `NtClose`; but this particular one (critical) doesn't.