### PR TITLE
Account for code caves beyond on-disk section in imgcoherency

### DIFF
--- a/phlib/include/phutil.h
+++ b/phlib/include/phutil.h
@@ -1086,6 +1086,7 @@ typedef enum _PH_IMGCOHERENCY_SCAN_TYPE
     * - Image header information
     * - Complete scan of all executable sections, this will include the entry point
     * - .NET manifests if appropriate
+    * - Scans for code caves in tail of mapped sections (virtual mapping > size on disk) 
     */
     PhImageCoherencyFull
 


### PR DESCRIPTION
This PR accounts for potential code caves within the virtual memory that spans beyond the size on disk to the virtual size. The loader will zero initialize this space, if someone modifies it they've written into the code cave.

In addition, this PR fixes a bug in the imgcoherency code which wouldn't correctly identify relocations.