### PR TITLE
Fix heap info processing on Win11 preview

### DIFF
--- a/ProcessHacker/memprv.c
+++ b/ProcessHacker/memprv.c
@@ -286,9 +286,11 @@ void PhpUpdateHeapRegions(
 
     if (debugBuffer->Heaps)
     {
+        PRTL_HEAP_INFORMATION heapInfo = debugBuffer->Heaps->Heaps;
+        const SIZE_T heapInfoSize = (PhOsVersion.dwBuildNumber >= 22523) ? sizeof(RTL_HEAP_INFORMATION_EX) : sizeof(RTL_HEAP_INFORMATION);
+
         for (ULONG i = 0; i < debugBuffer->Heaps->NumberOfHeaps; i++)
         {
-            PRTL_HEAP_INFORMATION heapInfo = &debugBuffer->Heaps->Heaps[i];
             PPH_MEMORY_ITEM heapMemoryItem;
 
             if (heapMemoryItem = PhpSetMemoryRegionType(List, heapInfo->BaseAddress, TRUE, HeapRegion))
@@ -313,6 +315,8 @@ void PhpUpdateHeapRegions(
                     }
                 }
             }
+
+            heapInfo = PTR_ADD_OFFSET(heapInfo, heapInfoSize);
         }
     }
 

--- a/phlib/native.c
+++ b/phlib/native.c
@@ -10312,9 +10312,11 @@ NTSTATUS PhQueryProcessHeapInformation(
     heapDebugInfo->NumberOfHeaps = debugBuffer->Heaps->NumberOfHeaps;
     heapDebugInfo->DefaultHeap = debugBuffer->ProcessHeap;
 
+    PRTL_HEAP_INFORMATION heapInfo = debugBuffer->Heaps->Heaps;
+    const SIZE_T heapInfoSize = (PhOsVersion.dwBuildNumber >= 22523) ? sizeof(RTL_HEAP_INFORMATION_EX) : sizeof(RTL_HEAP_INFORMATION);
+
     for (ULONG i = 0; i < heapDebugInfo->NumberOfHeaps; i++)
     {
-        PRTL_HEAP_INFORMATION heapInfo = &debugBuffer->Heaps->Heaps[i];
         HANDLE processHandle;
         SIZE_T allocated = 0;
         SIZE_T committed = 0;
@@ -10371,6 +10373,8 @@ NTSTATUS PhQueryProcessHeapInformation(
 
             NtClose(processHandle);
         }
+
+        heapInfo = PTR_ADD_OFFSET(heapInfo, heapInfoSize);
     }
 
     if (HeapInformation)

--- a/phnt/include/ntrtl.h
+++ b/phnt/include/ntrtl.h
@@ -3995,6 +3995,24 @@ typedef struct _RTL_HEAP_INFORMATION
     PRTL_HEAP_ENTRY Entries;
 } RTL_HEAP_INFORMATION, *PRTL_HEAP_INFORMATION;
 
+typedef struct _RTL_HEAP_INFORMATION_EX
+{
+    PVOID BaseAddress;
+    ULONG Flags;
+    USHORT EntryOverhead;
+    USHORT CreatorBackTraceIndex;
+    SIZE_T BytesAllocated;
+    SIZE_T BytesCommitted;
+    ULONG NumberOfTags;
+    ULONG NumberOfEntries;
+    ULONG NumberOfPseudoTags;
+    ULONG PseudoTagGranularity;
+    ULONG Reserved[5];
+    PRTL_HEAP_TAG Tags;
+    PRTL_HEAP_ENTRY Entries;
+    ULONG64 Tag;
+} RTL_HEAP_INFORMATION_EX, * PRTL_HEAP_INFORMATION_EX;
+
 #define RTL_HEAP_SIGNATURE 0xFFEEFFEEUL
 #define RTL_HEAP_SEGMENT_SIGNATURE 0xDDEEDDEEUL
 


### PR DESCRIPTION
Recent Win11 preview builds introduced new member into RTL_HEAP_INFORMATION structure.
Thus we will need to process heap info array differently based on OS build.