### PR TITLE
Theme: Enable dark theme for HANDLE properties subpages

### DIFF
--- a/ProcessHacker/include/phapp.h
+++ b/ProcessHacker/include/phapp.h
@@ -874,6 +874,12 @@ VOID PhShowTokenProperties(
     _In_opt_ PWSTR Title
     );
 
+INT CALLBACK PhpTokenSheetProc(
+    _In_ HWND hwndDlg,
+    _In_ UINT uMsg,
+    _In_ LPARAM lParam
+    );
+
 HPROPSHEETPAGE PhCreateTokenPage(
     _In_ PPH_OPEN_OBJECT OpenObject,
     _In_ HANDLE ProcessId,

--- a/ProcessHacker/ntobjprp.c
+++ b/ProcessHacker/ntobjprp.c
@@ -21,6 +21,7 @@
  */
 
 #include <phapp.h>
+#include <phsettings.h>
 
 typedef struct _COMMON_PAGE_CONTEXT
 {
@@ -205,6 +206,7 @@ INT_PTR CALLBACK PhpEventPageProc(
     case WM_INITDIALOG:
         {
             PhpRefreshEventPageInfo(hwndDlg, pageContext);
+            PhInitializeWindowTheme(hwndDlg, PhEnableThemeSupport);
         }
         break;
     case WM_COMMAND:
@@ -391,6 +393,7 @@ INT_PTR CALLBACK PhpSemaphorePageProc(
     case WM_INITDIALOG:
         {
             PhpRefreshSemaphorePageInfo(hwndDlg, pageContext);
+            PhInitializeWindowTheme(hwndDlg, PhEnableThemeSupport);
         }
         break;
     case WM_COMMAND:
@@ -501,6 +504,7 @@ INT_PTR CALLBACK PhpTimerPageProc(
     case WM_INITDIALOG:
         {
             PhpRefreshTimerPageInfo(hwndDlg, pageContext);
+            PhInitializeWindowTheme(hwndDlg, PhEnableThemeSupport);
         }
         break;
     case WM_COMMAND:

--- a/ProcessHacker/tokprp.c
+++ b/ProcessHacker/tokprp.c
@@ -224,17 +224,37 @@ VOID PhShowTokenProperties(
     propSheetHeader.dwFlags =
         PSH_NOAPPLYNOW |
         PSH_NOCONTEXTHELP |
-        PSH_PROPTITLE;
+        PSH_PROPTITLE |
+        PSH_USECALLBACK;
     propSheetHeader.hInstance = PhInstanceHandle;
     propSheetHeader.hwndParent = ParentWindowHandle;
     propSheetHeader.pszCaption = Title ? Title : L"Token";
     propSheetHeader.nPages = 1;
     propSheetHeader.nStartPage = 0;
     propSheetHeader.phpage = pages;
+    propSheetHeader.pfnCallback = PhpTokenSheetProc;
 
     pages[0] = PhCreateTokenPage(OpenObject, ProcessId, Context, NULL);
 
     PhModalPropertySheet(&propSheetHeader);
+}
+
+INT CALLBACK PhpTokenSheetProc(
+    _In_ HWND hwndDlg,
+    _In_ UINT uMsg,
+    _In_ LPARAM lParam
+)
+{
+    switch (uMsg)
+    {
+    case PSCB_INITIALIZED:
+        {
+            PhInitializeWindowTheme(hwndDlg, PhEnableThemeSupport);
+        }
+        break;
+    }
+
+    return 0;
 }
 
 HPROPSHEETPAGE PhCreateTokenPage(


### PR DESCRIPTION
Here is how it looks like now

Event
New
![image](https://user-images.githubusercontent.com/5801389/150569086-9c1406d8-d64a-4826-a3e5-2fd154a53a4b.png)
Old
![image](https://user-images.githubusercontent.com/5801389/150569220-02168cc3-9127-4f5d-98c4-c1f96d6e2a0a.png)


And security page
New
![image](https://user-images.githubusercontent.com/5801389/150569669-5eeeddb8-e5f1-4248-989a-a15aa7e547ad.png)
Old
![image](https://user-images.githubusercontent.com/5801389/150569457-454e9150-acdb-4ba5-90a7-a616b1ee3e99.png)

The check marks look a bit weird in my opinion maybe with a bit of hacking we could make the background around it transparent but then it would be hard to read against this dark background 🤷‍♂️, what do you think?  


