### PR TITLE
fixed faulty "plugins" solution & project-config

### DIFF
--- a/plugins/HardwareDevices/HardwareDevices.vcxproj
+++ b/plugins/HardwareDevices/HardwareDevices.vcxproj
@@ -99,6 +99,7 @@
     <Link>
       <AdditionalDependencies>cfgmgr32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
       <DelayLoadDLLs>cfgmgr32.dll;iphlpapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
+      <AssemblyDebug>false</AssemblyDebug>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">

--- a/plugins/HardwareDevices/HardwareDevices.vcxproj
+++ b/plugins/HardwareDevices/HardwareDevices.vcxproj
@@ -98,8 +98,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <AdditionalDependencies>cfgmgr32.lib;iphlpapi.lib;%(AdditionalDependencies)</AdditionalDependencies>
-      <DelayLoadDLLs>cfgmgr32.dll;iphlpapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
-      <AssemblyDebug>false</AssemblyDebug>
+      <DelayLoadDLLs>cfgmgr32.dll;iphlpapi.dll;%(DelayLoadDLLs)</DelayLoadDLLs>      
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">

--- a/plugins/Plugins.props
+++ b/plugins/Plugins.props
@@ -36,7 +36,7 @@
             <SupportJustMyCode>false</SupportJustMyCode>
         </ClCompile>
         <Link>
-            <AdditionalDependencies>ProcessHacker.lib;thirdparty.lib;ntdll.lib;noenv.obj;noarg.obj;%(AdditionalDependencies)</AdditionalDependencies>
+            <AdditionalDependencies>$(SolutionDir)..\bin\$(Configuration)$(PlatformArchitecture)\ProcessHacker.lib;thirdparty.lib;ntdll.lib;noenv.obj;noarg.obj;%(AdditionalDependencies)</AdditionalDependencies>
             <GenerateDebugInformation>true</GenerateDebugInformation>
             <SubSystem>Windows</SubSystem>
             <AdditionalOptions>/BREPRO /DEPENDENTLOADFLAG:0x800 /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>

--- a/plugins/WindowExplorer/WindowExplorer.vcxproj
+++ b/plugins/WindowExplorer/WindowExplorer.vcxproj
@@ -96,7 +96,7 @@
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
     <Link>
       <DelayLoadDLLs>comctl32.dll;gdi32.dll;ole32.dll;ProcessHacker.exe;propsys.dll;shell32.dll;user32.dll;%(DelayLoadDLLs)</DelayLoadDLLs>
-      <AdditionalDependencies>ProcessHacker.lib;ntdll.lib;propsys.lib;%(AdditionalDependencies)</AdditionalDependencies>
+      <AdditionalDependencies>ntdll.lib;propsys.lib;%(AdditionalDependencies)</AdditionalDependencies>
     </Link>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">


### PR DESCRIPTION
A clean checkout of the repository yields a defunct state of the "plugins" solution - this PR fixes that.
Someone really should also fix the CI.