### PR TITLE
Fix compiler errors for ARM64 build

### DIFF
--- a/phlib/include/phnative.h
+++ b/phlib/include/phnative.h
@@ -1825,6 +1825,31 @@ typedef struct _PH_PROCESS_DEBUG_HEAP_INFORMATION32
     PH_PROCESS_DEBUG_HEAP_ENTRY32 Heaps[1];
 } PH_PROCESS_DEBUG_HEAP_INFORMATION32, *PPH_PROCESS_DEBUG_HEAP_INFORMATION32;
 
+typedef struct _PH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64 {
+    DWORD BeginAddress;
+    DWORD EndAddress;
+    union {
+        DWORD UnwindInfoAddress;
+        DWORD UnwindData;
+    } DUMMYUNIONNAME;
+} PH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64, *PPH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64;
+
+typedef struct _PH_IMAGE_RUNTIME_FUNCTION_ENTRY_ARM64 {
+    DWORD BeginAddress;
+    union {
+        DWORD UnwindData;
+        struct {
+            DWORD Flag : 2;
+            DWORD FunctionLength : 11;
+            DWORD RegF : 3;
+            DWORD RegI : 4;
+            DWORD H : 1;
+            DWORD CR : 2;
+            DWORD FrameSize : 9;
+        } DUMMYSTRUCTNAME;
+    } DUMMYUNIONNAME;
+} PH_IMAGE_RUNTIME_FUNCTION_ENTRY_ARM64, *PPH_IMAGE_RUNTIME_FUNCTION_ENTRY_ARM64;
+
 PHLIBAPI
 NTSTATUS
 NTAPI

--- a/phlib/symprv.c
+++ b/phlib/symprv.c
@@ -1963,14 +1963,14 @@ NTSTATUS PhWalkThreadStack(
         stackFrame.StackFrameSize = sizeof(STACKFRAME_EX);
 
         // Program counter, Stack pointer, Frame pointer
-#ifdef _ARM64_
+#if defined(_ARM64_)
         stackFrame.AddrPC.Mode = AddrModeFlat;
         stackFrame.AddrPC.Offset = context.Pc;
         stackFrame.AddrStack.Mode = AddrModeFlat;
         stackFrame.AddrStack.Offset = context.Sp;
         stackFrame.AddrFrame.Mode = AddrModeFlat;
         stackFrame.AddrFrame.Offset = context.Fp;
-#else
+#elif defined(_AMD64_)
         stackFrame.AddrPC.Mode = AddrModeFlat;
         stackFrame.AddrPC.Offset = context.Rip;
         stackFrame.AddrStack.Mode = AddrModeFlat;

--- a/tools/peview/peexceptprp.c
+++ b/tools/peview/peexceptprp.c
@@ -287,7 +287,6 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
 
             if (imageMachine == IMAGE_FILE_MACHINE_I386)
             {
-                PhSaveListViewColumnsToSetting(L"ImageExceptions32ListViewColumns", context->ListViewHandle);
                 PhSaveListViewColumnsToSetting(L"ImageExceptionsIa32ListViewColumns", context->ListViewHandle);
             }
             else if (imageMachine == IMAGE_FILE_MACHINE_AMD64)

--- a/tools/peview/peexceptprp.c
+++ b/tools/peview/peexceptprp.c
@@ -115,7 +115,7 @@ VOID PvEnumerateExceptionEntries(
     {
         for (ULONG i = 0; i < exceptions.NumberOfEntries; i++)
         {
-            PIMAGE_RUNTIME_FUNCTION_ENTRY entry = PTR_ADD_OFFSET(exceptions.ExceptionDirectory, i * sizeof(IMAGE_RUNTIME_FUNCTION_ENTRY));
+            PPH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64 entry = PTR_ADD_OFFSET(exceptions.ExceptionDirectory, i * sizeof(PH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64));
             INT lvItemIndex;
             PPH_STRING symbol;
             PPH_STRING symbolName = NULL;
@@ -175,19 +175,23 @@ VOID PvEnumerateExceptionEntries(
             }
         }
     }
+    else if (imageMachine == IMAGE_FILE_MACHINE_ARM64)
+    {
+        /* Todo */
+    }
 
     //ExtendedListView_SortItems(ListViewHandle);
     ExtendedListView_SetRedraw(ListViewHandle, TRUE);
 }
 
-INT NTAPI PvpPeExceptionSizeCompareFunction(
+INT NTAPI PvpPeExceptionSizeCompareFunctionAmd64(
     _In_ PVOID Item1,
     _In_ PVOID Item2,
     _In_ PVOID Context
     )
 {
-    PIMAGE_RUNTIME_FUNCTION_ENTRY entry1 = Item1;
-    PIMAGE_RUNTIME_FUNCTION_ENTRY entry2 = Item2;
+    PPH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64 entry1 = Item1;
+    PPH_IMAGE_RUNTIME_FUNCTION_ENTRY_AMD64 entry2 = Item2;
 
     return uintptrcmp((ULONG_PTR)entry1->EndAddress - entry1->BeginAddress, (ULONG_PTR)entry2->EndAddress - entry2->BeginAddress);
 }
@@ -257,7 +261,11 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
                 PhAddListViewColumn(context->ListViewHandle, 6, 6, 6, LVCFMT_LEFT, 100, L"Section");
                 PhLoadListViewColumnsFromSetting(L"ImageExceptions64ListViewColumns", context->ListViewHandle);
 
-                ExtendedListView_SetCompareFunction(context->ListViewHandle, 4, PvpPeExceptionSizeCompareFunction);
+                ExtendedListView_SetCompareFunction(context->ListViewHandle, 4, PvpPeExceptionSizeCompareFunctionAmd64);
+            }
+            else if (imageMachine == IMAGE_FILE_MACHINE_ARM64)
+            {
+                /* Todo */
             }
 
             PhInitializeLayoutManager(&context->LayoutManager, hwndDlg);
@@ -284,6 +292,10 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
             else if (imageMachine == IMAGE_FILE_MACHINE_AMD64)
             {
                 PhSaveListViewColumnsToSetting(L"ImageExceptions64ListViewColumns", context->ListViewHandle);
+            }
+            else if (imageMachine == IMAGE_FILE_MACHINE_ARM64)
+            {
+                /* Todo */
             }
 
             PhDeleteLayoutManager(&context->LayoutManager);

--- a/tools/peview/peexceptprp.c
+++ b/tools/peview/peexceptprp.c
@@ -249,7 +249,7 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
                 PhAddListViewColumn(context->ListViewHandle, 1, 1, 1, LVCFMT_LEFT, 100, L"SEH Handler");
                 PhAddListViewColumn(context->ListViewHandle, 2, 2, 2, LVCFMT_LEFT, 200, L"Symbol");
                 PhAddListViewColumn(context->ListViewHandle, 3, 3, 3, LVCFMT_LEFT, 100, L"Section");
-                PhLoadListViewColumnsFromSetting(L"ImageExceptions32ListViewColumns", context->ListViewHandle);
+                PhLoadListViewColumnsFromSetting(L"ImageExceptionsIa32ListViewColumns", context->ListViewHandle);
             }
             else if (imageMachine == IMAGE_FILE_MACHINE_AMD64)
             {
@@ -259,7 +259,7 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
                 PhAddListViewColumn(context->ListViewHandle, 4, 4, 4, LVCFMT_LEFT, 100, L"Size");
                 PhAddListViewColumn(context->ListViewHandle, 5, 5, 5, LVCFMT_LEFT, 200, L"Symbol");
                 PhAddListViewColumn(context->ListViewHandle, 6, 6, 6, LVCFMT_LEFT, 100, L"Section");
-                PhLoadListViewColumnsFromSetting(L"ImageExceptions64ListViewColumns", context->ListViewHandle);
+                PhLoadListViewColumnsFromSetting(L"ImageExceptionsAmd64ListViewColumns", context->ListViewHandle);
 
                 ExtendedListView_SetCompareFunction(context->ListViewHandle, 4, PvpPeExceptionSizeCompareFunctionAmd64);
             }
@@ -288,10 +288,11 @@ INT_PTR CALLBACK PvpPeExceptionDlgProc(
             if (imageMachine == IMAGE_FILE_MACHINE_I386)
             {
                 PhSaveListViewColumnsToSetting(L"ImageExceptions32ListViewColumns", context->ListViewHandle);
+                PhSaveListViewColumnsToSetting(L"ImageExceptionsIa32ListViewColumns", context->ListViewHandle);
             }
             else if (imageMachine == IMAGE_FILE_MACHINE_AMD64)
             {
-                PhSaveListViewColumnsToSetting(L"ImageExceptions64ListViewColumns", context->ListViewHandle);
+                PhSaveListViewColumnsToSetting(L"ImageExceptionsAmd64ListViewColumns", context->ListViewHandle);
             }
             else if (imageMachine == IMAGE_FILE_MACHINE_ARM64)
             {

--- a/tools/peview/settings.c
+++ b/tools/peview/settings.c
@@ -61,8 +61,8 @@ VOID PhAddDefaultSettings(
     PhpAddStringSetting(L"ImageResourcesTreeListColumns", L"");
     PhpAddStringSetting(L"ImageResourcesTreeListSort", L"0,1"); // 0, AscendingSortOrder
     PhpAddStringSetting(L"ImageLoadCfgListViewColumns", L"");
-    PhpAddStringSetting(L"ImageExceptions32ListViewColumns", L"");
-    PhpAddStringSetting(L"ImageExceptions64ListViewColumns", L"");
+    PhpAddStringSetting(L"ImageExceptionsIa32ListViewColumns", L"");
+    PhpAddStringSetting(L"ImageExceptionsAmd64ListViewColumns", L"");
     PhpAddStringSetting(L"ImageHeadersListViewColumns", L"");
     PhpAddStringSetting(L"ImageHeadersListViewGroupStates", L"");
     PhpAddStringSetting(L"ImageLayoutTreeColumns", L"");


### PR DESCRIPTION
My understanding is this code loads the image then reads the exception entries. Unfortunately in this case, the only runtime function entry struct that `winnt.h` loads is for the current architecture being compiled for. This pull request brings both AMD64 and ARM64 runtime function entry definitions into Process Hacker's headers in order to fix errors due to struct entries that are missing.