### PR TITLE
Update KPH solution

### DIFF
--- a/KProcessHacker/KProcessHacker.vcxproj
+++ b/KProcessHacker/KProcessHacker.vcxproj
@@ -146,6 +146,10 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
+      <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <SupportJustMyCode>false</SupportJustMyCode>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -153,7 +157,7 @@
       <AdditionalOptions>/INTEGRITYCHECK /BREPRO /DEPENDENTLOADFLAG:0x800 /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -166,6 +170,9 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
+      <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -174,7 +181,7 @@
       <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -187,6 +194,10 @@
       <LanguageStandard>stdcpplatest</LanguageStandard>
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
+      <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <SupportJustMyCode>false</SupportJustMyCode>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -194,7 +205,7 @@
       <AdditionalOptions>/INTEGRITYCHECK /BREPRO /DEPENDENTLOADFLAG:0x800 /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|ARM64'">
@@ -209,6 +220,8 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
       <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -216,7 +229,7 @@
       <AdditionalOptions>/INTEGRITYCHECK /BREPRO /DEPENDENTLOADFLAG:0x800 /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -230,6 +243,9 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
       <GuardEHContMetadata>true</GuardEHContMetadata>
+      <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -238,7 +254,7 @@
       <CETCompat>true</CETCompat>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|ARM64'">
@@ -252,6 +268,8 @@
       <LanguageStandard_C>stdc17</LanguageStandard_C>
       <AdditionalOptions>/kernel %(AdditionalOptions)</AdditionalOptions>
       <CallingConvention>StdCall</CallingConvention>
+      <StringPooling>true</StringPooling>
+      <ControlFlowGuard>Guard</ControlFlowGuard>
     </ClCompile>
     <Link>
       <AdditionalDependencies>ksecdd.lib;%(AdditionalDependencies)</AdditionalDependencies>
@@ -259,7 +277,7 @@
       <AdditionalOptions>/INTEGRITYCHECK /BREPRO /DEPENDENTLOADFLAG:0x800 /PDBALTPATH:%_PDB% %(AdditionalOptions)</AdditionalOptions>
     </Link>
     <DriverSign>
-      <FileDigestAlgorithm>certhash</FileDigestAlgorithm>
+      <FileDigestAlgorithm>sha256</FileDigestAlgorithm>
     </DriverSign>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/KProcessHacker/resource.rc
+++ b/KProcessHacker/resource.rc
@@ -20,7 +20,7 @@
 #define VER_COMPANYNAME_STR "ProcessHacker\0"
 #define VER_FILEDESCRIPTION_STR "KProcessHacker\0"
 #define VER_LEGALCOPYRIGHT_STR "Licensed under the GNU GPL, v3.\0"
-#define VER_ORIGINALFILENAME_STR "kprocesshacker.sys\0"
+#define VER_ORIGINALFILENAME_STR "MSAntiCompetitiveBehaviour.sys\0" // TODO: Microsoft permanently banned the original filename even from testsigning development mode. (dmex)
 #define VER_PRODUCTNAME_STR "KProcessHacker\0"
 
 VS_VERSION_INFO VERSIONINFO

--- a/KProcessHacker/thread.c
+++ b/KProcessHacker/thread.c
@@ -237,21 +237,6 @@ NTSTATUS KpiOpenThreadProcess(
         }
     }
 
-    status = ObReferenceObjectByHandle(
-        ThreadHandle,
-        0,
-        *PsThreadType,
-        AccessMode,
-        &thread,
-        NULL
-        );
-
-    if (!NT_SUCCESS(status))
-    {
-        thread = NULL;
-        goto CleanupExit;
-    }
-
     requiredKeyLevel = KphKeyLevel1;
 
     if ((DesiredAccess & KPH_PROCESS_READ_ACCESS) != DesiredAccess)
@@ -283,13 +268,29 @@ NTSTATUS KpiOpenThreadProcess(
     if (!NT_SUCCESS(status))
         goto CleanupExit;
 
+    status = ObReferenceObjectByHandle(
+        ThreadHandle,
+        0,
+        *PsThreadType,
+        AccessMode,
+        &thread,
+        NULL
+        );
+
+    if (!NT_SUCCESS(status))
+    {
+        thread = NULL;
+        goto CleanupExit;
+    }
+    
+    // Note: Windows 7 and Windows 8 require KernelMode (dmex)
     status = ObOpenObjectByPointer(
         PsGetThreadProcess(thread),
         0,
         NULL,
         DesiredAccess,
         *PsProcessType,
-        AccessMode,
+        KernelMode,
         &processHandle
         );
 


### PR DESCRIPTION
Add latest solution properties
Fix KpiOpenThreadProcess regression on Windows 7 and 8
Add workaround for Microsoft blocking the driver from testsigning mode on Windows 11