### PR TITLE
Update used LDRP flags in modlist.c & modprv.c.

### DIFF
--- a/ProcessHacker/modlist.c
+++ b/ProcessHacker/modlist.c
@@ -1134,7 +1134,7 @@ BOOLEAN NTAPI PhpModuleTreeNewCallback(
                 getNodeColor->BackColor = PhCsColorDotNet;
             else if (context->HighlightImmersiveModules && (moduleItem->ImageDllCharacteristics & IMAGE_DLLCHARACTERISTICS_APPCONTAINER))
                 getNodeColor->BackColor = PhCsColorImmersiveProcesses;
-            else if (context->HighlightRelocatedModules && (moduleItem->Flags & LDRP_IMAGE_NOT_AT_BASE))
+            else if (context->HighlightRelocatedModules && (moduleItem->Flags & LDRP_COR_DEFERRED_VALIDATE))
                 getNodeColor->BackColor = PhCsColorRelocatedModules;
             else if (PhEnableProcessQueryStage2 &&
                 context->HighlightSystemModules &&

--- a/ProcessHacker/modprv.c
+++ b/ProcessHacker/modprv.c
@@ -705,7 +705,7 @@ VOID PhModuleProviderUpdate(
                 // 1. It (should be) faster than opening the file and mapping it in, and
                 // 2. It contains the correct original image base relocated by ASLR, if present.
 
-                moduleItem->Flags &= ~LDRP_IMAGE_NOT_AT_BASE;
+                moduleItem->Flags &= ~LDRP_COR_DEFERRED_VALIDATE;
 
                 if (NT_SUCCESS(PhLoadRemoteMappedImageEx(moduleProvider->ProcessHandle, moduleItem->BaseAddress, readVirtualMemoryCallback, &remoteMappedImage)))
                 {
@@ -735,7 +735,7 @@ VOID PhModuleProviderUpdate(
                     }
 
                     if (imageBase != (ULONG_PTR)moduleItem->BaseAddress)
-                        moduleItem->Flags |= LDRP_IMAGE_NOT_AT_BASE;
+                        moduleItem->Flags |= LDRP_COR_DEFERRED_VALIDATE;
 
                     if (entryPoint != 0)
                         moduleItem->EntryPoint = PTR_ADD_OFFSET(moduleItem->BaseAddress, entryPoint);


### PR DESCRIPTION
Fixes build issues when attempting to build the latest commit of Process Hacker & the plugins, as these files were still referencing the older `LDRP_IMAGE_NOT_AT_BASE` constant rather than `LDRP_COR_DEFERRED_VALIDATE`.