### PR TITLE
Add support for Audit XFG mode

### DIFF
--- a/ProcessHacker/include/procprv.h
+++ b/ProcessHacker/include/procprv.h
@@ -172,7 +172,8 @@ typedef struct _PH_PROCESS_ITEM
             ULONG IsControlFlowGuardEnabled : 1;
             ULONG IsCetEnabled : 1;
             ULONG IsXfgEnabled : 1;
-            ULONG Spare : 12;
+            ULONG IsXfgAuditEnabled : 1;
+            ULONG Spare : 11;
         };
     };
 

--- a/ProcessHacker/procmtgn.c
+++ b/ProcessHacker/procmtgn.c
@@ -309,6 +309,13 @@ BOOLEAN PhDescribeProcessMitigationPolicy(
                     PhInitializeStringBuilder(&sb, 50);
                     if (data->StrictMode) PhAppendStringBuilder2(&sb, L"Strict ");
 
+#if !defined(NTDDI_WIN10_CO) || (NTDDI_VERSION < NTDDI_WIN10_CO)
+                    if (_bittest((const PLONG)&data->Flags, 4))
+#else
+                    if (data->EnableXfgAuditMode)
+#endif
+                        PhAppendStringBuilder2(&sb, L"Audit ");
+
                 #if !defined(NTDDI_WIN10_CO) || (NTDDI_VERSION < NTDDI_WIN10_CO)
                     PhAppendStringBuilder2(&sb, _bittest((const PLONG)&data->Flags, 3) ? L"XF Guard" : L"CF Guard");
                 #else
@@ -330,6 +337,7 @@ BOOLEAN PhDescribeProcessMitigationPolicy(
                     {
                         PhAppendStringBuilder2(&sb, L"Extended Control Flow Guard (XFG) is enabled for the process.\r\n");
 
+                        if (data->EnableXfgAuditMode) PhAppendStringBuilder2(&sb, L"Audit XFG : XFG is running in audit mode.\r\n");
                         if (data->StrictMode) PhAppendStringBuilder2(&sb, L"Strict XFG : only XFG modules can be loaded.\r\n");
                         if (data->EnableExportSuppression) PhAppendStringBuilder2(&sb, L"Dll Exports can be marked as XFG invalid targets.\r\n");
                     }

--- a/ProcessHacker/procprv.c
+++ b/ProcessHacker/procprv.c
@@ -1393,10 +1393,12 @@ VOID PhpFillProcessItem(
         if (WindowsVersion >= WINDOWS_11)
         {
             BOOLEAN xfguardEnabled;
+            BOOLEAN xfguardAuditEnabled;
 
-            if (NT_SUCCESS(PhGetProcessIsXFGuardEnabled(ProcessItem->QueryHandle, &xfguardEnabled)))
+            if (NT_SUCCESS(PhGetProcessIsXFGuardEnabled(ProcessItem->QueryHandle, &xfguardEnabled, &xfguardAuditEnabled)))
             {
                 ProcessItem->IsXfgEnabled = xfguardEnabled;
+                ProcessItem->IsXfgAuditEnabled = xfguardAuditEnabled;
             }
         }
     }

--- a/ProcessHacker/proctree.c
+++ b/ProcessHacker/proctree.c
@@ -2068,7 +2068,13 @@ BEGIN_SORT_FUNCTION(CfGuard)
 
     if (sortResult == 0)
     {
-        sortResult = uintcmp(node1->ProcessItem->IsControlFlowGuardEnabled, node2->ProcessItem->IsControlFlowGuardEnabled);
+        // prefer XFG audit over CFG
+        sortResult = uintcmp(node1->ProcessItem->IsXfgAuditEnabled, node2->ProcessItem->IsXfgAuditEnabled);
+
+        if (sortResult == 0)
+        {
+            sortResult = uintcmp(node1->ProcessItem->IsControlFlowGuardEnabled, node2->ProcessItem->IsControlFlowGuardEnabled);
+        }
     }
 }
 END_SORT_FUNCTION
@@ -3169,7 +3175,9 @@ BOOLEAN NTAPI PhpProcessTreeNewCallback(
                 }
                 break;
             case PHPRTLC_CFGUARD:
-                if (processItem->IsXfgEnabled)
+                if (processItem->IsXfgAuditEnabled)
+                    PhInitializeStringRef(&getCellText->Text, L"XF Guard (audit)");
+                else if (processItem->IsXfgEnabled)
                     PhInitializeStringRef(&getCellText->Text, L"XF Guard");
                 else if (processItem->IsControlFlowGuardEnabled)
                     PhInitializeStringRef(&getCellText->Text, L"CF Guard");

--- a/phlib/include/phnativeinl.h
+++ b/phlib/include/phnativeinl.h
@@ -724,8 +724,9 @@ FORCEINLINE
 NTSTATUS
 PhGetProcessIsXFGuardEnabled(
     _In_ HANDLE ProcessHandle,
-    _Out_ PBOOLEAN IsXFGuardEnabled
-)
+    _Out_ PBOOLEAN IsXFGuardEnabled,
+    _Out_ PBOOLEAN IsXFGuardAuditEnabled
+    )
 {
     NTSTATUS status;
     PROCESS_MITIGATION_POLICY_INFORMATION policyInfo;
@@ -744,8 +745,10 @@ PhGetProcessIsXFGuardEnabled(
     {
 #if !defined(NTDDI_WIN10_CO) || (NTDDI_VERSION < NTDDI_WIN10_CO)
         *IsXFGuardEnabled = _bittest((const PLONG)&policyInfo.ControlFlowGuardPolicy.Flags, 3);
+        *IsXFGuardAuditEnabled = _bittest((const PLONG)&policyInfo.ControlFlowGuardPolicy.Flags, 4);
 #else
         *IsXFGuardEnabled = !!policyInfo.ControlFlowGuardPolicy.EnableXfg;
+        *IsXFGuardAuditEnabled = !!policyInfo.ControlFlowGuardPolicy.EnableXfgAuditMode;
 #endif
     }
 

--- a/tools/peview/ldprp.c
+++ b/tools/peview/ldprp.c
@@ -63,9 +63,9 @@ PPH_STRING PvpGetPeGuardFlagsText(
     if (GuardFlags & IMAGE_GUARD_DELAYLOAD_IAT_IN_ITS_OWN_SECTION)
         PhAppendStringBuilder2(&stringBuilder, L"Delay-load private section, ");
     if (GuardFlags & IMAGE_GUARD_CF_ENABLE_EXPORT_SUPPRESSION)
-        PhAppendStringBuilder2(&stringBuilder, L"Export supression, ");
+        PhAppendStringBuilder2(&stringBuilder, L"Export suppression, ");
     if (GuardFlags & IMAGE_GUARD_CF_EXPORT_SUPPRESSION_INFO_PRESENT)
-        PhAppendStringBuilder2(&stringBuilder, L"Export information supression, ");
+        PhAppendStringBuilder2(&stringBuilder, L"Export information suppression, ");
     if (GuardFlags & IMAGE_GUARD_CF_LONGJUMP_TABLE_PRESENT)
         PhAppendStringBuilder2(&stringBuilder, L"Longjump table, ");
     if (GuardFlags & IMAGE_GUARD_RETPOLINE_PRESENT)


### PR DESCRIPTION
This change will display whether XFG is running in Audit mode or not in process tree

![image](https://user-images.githubusercontent.com/5801389/172127868-ecce9d13-bb66-4d2c-ac45-99c3d4a57363.png)

and also in details

![image](https://user-images.githubusercontent.com/5801389/172127970-347e9fda-8f2a-4b75-a486-4af27397ae52.png)

